### PR TITLE
fix: Fix default display right angle

### DIFF
--- a/src/dplatformhandle.cpp
+++ b/src/dplatformhandle.cpp
@@ -546,8 +546,10 @@ bool DPlatformHandle::isEnabledDXcb(const QWindow *window)
 static void initWindowRadius(QWindow *window)
 {
     auto theme = DGuiApplicationHelper::instance()->windowTheme(window);
-    //###(zccrs): 暂时在此处给窗口默认设置为18px的圆角
-    int radius = theme->windowRadius(18);
+    int radius = theme->windowRadius();
+
+    if (radius == -1)
+        radius =theme->windowRadius(18); //###(zccrs): 暂时在此处给窗口默认设置为18px的圆角
 
     setWindowProperty(window, _windowRadius, radius);
     window->connect(theme, &DPlatformTheme::windowRadiusChanged, window, [=] (int radius) {

--- a/src/dplatformtheme.cpp
+++ b/src/dplatformtheme.cpp
@@ -391,10 +391,8 @@ int DPlatformTheme::windowRadius() const
 
 int DPlatformTheme::windowRadius(int defaultValue) const
 {
-    FETCH_PROPERTY("DTK/WindowRadius", windowRadius)
-
     bool ok = false;
-    int radius = value.toInt(&ok);
+    int radius = this->property("windowRadius").toInt(&ok);
 
     return ok ? radius : defaultValue;
 }


### PR DESCRIPTION
A call to `FETCH_PROPERTY("DTK/WindowRadius", windowRadius)` will return -1 by default, resulting in the right angle parameter. So the cup is fixed here.

Log: