### PR TITLE
Use detected pkg-config to fix cross build.

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -7,7 +7,7 @@ CONFIG += internal_module
 contains(QMAKE_HOST.arch, mips.*): QMAKE_LFLAGS_SHLIB += "-Wl,-z,noexecstack"
 
 # don't link library
-QMAKE_CXXFLAGS += $$system(pkg-config --cflags-only-I librsvg-2.0)
+QMAKE_CXXFLAGS += $$system($$pkgConfigExecutable() --cflags-only-I librsvg-2.0)
 
 INCLUDEPATH += \
     $$PWD/filedrag \


### PR DESCRIPTION
Use detected pkg-config to fix cross-build in Debian.
Debian Bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=979451