### PR TITLE
fix: 修改深色模式下TextWarning的色值

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -478,7 +478,7 @@ static QColor dark_dpalette[DPalette::NColorTypes] {
     QColor(255, 255, 255, 255 * 0.05),  //ItemBackground
     QColor("#C0C6D4"),                  //TextTitle
     QColor("#6D7C88"),                  //TextTips
-    QColor("#9a2f2f"),                  //TextWarning
+    QColor("#E43F2E"),                  //TextWarning
     Qt::white,                          //TextLively
     QColor("#0059d2"),                  //LightLively
     QColor("#0059d2"),                  //DarkLively


### PR DESCRIPTION
修改深色模式下TextWarning的色值为E43F2E

Log:
Task: https://pms.uniontech.com/task-view-138099.html
Influence: 深色模式TextWarning调色板