### PR TITLE
fix: build failed when the .git folder exist

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,9 +5,6 @@ export QT_SELECT = qt5
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
-ifneq (,$(wildcard .git/config))
-	CONFIG_VERSION=
-else
 VERSION = $(DEB_VERSION_UPSTREAM)
 _PACK_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$1}')
 _BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g')
@@ -15,7 +12,6 @@ ifeq ($(_BUILD_VER),)
 	CONFIG_VERSION = $(_PACK_VER)
 else
 	CONFIG_VERSION = $(_PACK_VER).$(_BUILD_VER)
-endif
 endif
 
 %:


### PR DESCRIPTION
build failed when the .git folder exist

Log: fix build failed when the .git folder exist

Resolve: https://github.com/linuxdeepin/developer-center/issues/3328