### PR TITLE
feat: Register the DciIcon as a meta type

### DIFF
--- a/src/util/ddciicon.cpp
+++ b/src/util/ddciicon.cpp
@@ -776,4 +776,24 @@ DDciIcon DDciIcon::fromTheme(const QString &name, const DDciIcon &fallback)
     return icon;
 }
 
+#ifndef QT_NO_DATASTREAM
+QDataStream &operator<<(QDataStream &s, const DDciIcon &icon)
+{
+    if (icon.isNull())
+        return s << QByteArray();
+    auto dciFile = icon.d->dciFile;
+    const QByteArray &data = dciFile->toData();
+    s << data;
+    return s;
+}
+
+QDataStream &operator>>(QDataStream &s, DDciIcon &icon)
+{
+    QByteArray data;
+    s >> data;
+    icon = DDciIcon(data);
+    return s;
+}
+#endif
+
 DGUI_END_NAMESPACE

--- a/src/util/ddciicon.h
+++ b/src/util/ddciicon.h
@@ -93,6 +93,16 @@ public:
     // TODO: Should be compatible with QIcon
 private:
     QSharedDataPointer<DDciIconPrivate> d;
+#ifndef QT_NO_DATASTREAM
+    friend QDataStream &operator<<(QDataStream &, const DDciIcon &);
+    friend QDataStream &operator>>(QDataStream &, DDciIcon &);
+#endif
 };
 
+#ifndef QT_NO_DATASTREAM
+QDataStream &operator<<(QDataStream &, const DDciIcon &);
+QDataStream &operator>>(QDataStream &, DDciIcon &);
+#endif
+
 DGUI_END_NAMESPACE
+Q_DECLARE_METATYPE(DTK_GUI_NAMESPACE::DDciIcon);


### PR DESCRIPTION
After registering the DciIcon as a meta type, it is
convenient for applications to use it on QVariant.

The << and >> operators are provided to facilitate
applications to read and write.

Log:
Influence: None
Change-Id: I0df76a9e5378a46dcb075b2368fd05eb360d074d