### PR TITLE
chore: Add stream operators for DciIcon

### DIFF
--- a/src/util/ddciicon.cpp
+++ b/src/util/ddciicon.cpp
@@ -249,6 +249,14 @@ public:
     EntryNodeList icons;
 };
 
+#ifndef QT_NO_DATASTREAM
+__attribute__((constructor))
+static void registerMetaType()
+{
+    qRegisterMetaTypeStreamOperators<DDciIcon>("DDciIcon");
+}
+#endif
+
 static inline bool toMode(const QStringRef &name, DDciIcon::Mode *mode) {
     if (name == QLatin1String(MODE_NORMAL)) {
         *mode = DDciIcon::Normal;


### PR DESCRIPTION
Register the stream operators when the ddciicon
has been initialized. It is convenient to drag
and drop in the list view and register it into
the meta object.

Log:
Influence: None
Change-Id: I90ba9199bd3139e0423f1a3d8a6897990e697708