### PR TITLE
fix(build): invalid digit "8" in octal constant

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 VERSION = $(DEB_VERSION_UPSTREAM)
 _PACK_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$1}')
-_BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g')
+_BUILD_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$2}' | sed 's/[^0-9]//g' | awk '{print int($$1)}')
 ifeq ($(_BUILD_VER),)
 	CONFIG_VERSION = $(_PACK_VER)
 else


### PR DESCRIPTION
when BUILD_VERSION start with 0 was recognized as octal

Log:
Influence: debian build
Change-Id: Ic71784120cacd66f763a72f38937fc0d99fb0454