### PR TITLE
fix: XdgIcon crashed in release mode

### DIFF
--- a/src/util/private/xdgiconproxyengine.cpp
+++ b/src/util/private/xdgiconproxyengine.cpp
@@ -29,7 +29,7 @@
 static bool XdgIconFollowColorScheme()
 {
     // XdgIcon::followColorScheme()
-    XdgIconLoader::instance()->followColorScheme();
+    return XdgIconLoader::instance()->followColorScheme();
 }
 
 #if XDG_ICON_VERSION_MAR >= 3


### PR DESCRIPTION
The return value is not processed effectively, resulting
in an exception under release mode.

Log:
Change-Id: I0c6e918a99fd6f28a441c23a28c786dac572f5e2