### PR TITLE
fix: Cast error when platform theme changed

### DIFF
--- a/src/kernel/dplatformtheme.cpp
+++ b/src/kernel/dplatformtheme.cpp
@@ -100,7 +100,11 @@ void DPlatformThemePrivate::_q_onThemePropertyChanged(const QByteArray &name, co
     }
 
     if (p.hasNotifySignal()) {
-        p.notifySignal().invoke(q, QGenericArgument(value.typeName(), value.constData()));
+        // invoke会做Q_ASSERT(mobj->cast(object))判断, DPlatformTheme的dynamic metaObject为
+        // qt5platform-plugin插件的DNativeSettings. 导致崩溃.
+        // invokeOnGadget与invoke代码逻辑一致, 只是少了异步支持.
+        if (!p.notifySignal().invokeOnGadget(q, QGenericArgument(value.typeName(), value.constData())))
+            qWarning() << "_q_onThemePropertyChanged() error when notify signal" << p.notifySignal().name();
     }
 }
 


### PR DESCRIPTION
  QMetaMethod::invoke will test whether object is an instance
of the QMetaObject as Q_ASSERT(mobj->cast(object)), but invokeOnGadge will not, and their role seem to be the same, we only use DirectConnection to invoke it.
  DPlatformTheme is inherits DNativeSettings, and it's metaobject
is changed to DNativeSettings in qt5platform-plugin.

Log: 调用invoke会做assert判断，导致当qt为debug编译时，改变主题会导致程序崩溃
Influence: 当qt为debug编译时，改变主题会导致程序崩溃
Change-Id: I9133430ba6f3df4c4a806ff9fa96ba8ec8213ce4