### PR TITLE
fix: Application theme can't follow change by system

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -105,13 +105,6 @@ DGuiApplicationHelperPrivate::DGuiApplicationHelperPrivate(DGuiApplicationHelper
 
 void DGuiApplicationHelperPrivate::init()
 {
-    D_Q(DGuiApplicationHelper);
-
-    systemTheme = new DPlatformTheme(0, q);
-    // 直接对应到系统级别的主题, 不再对外提供为某个单独程序设置主题的接口.
-    // 程序设置自身主题相关的东西皆可通过 setPaletteType 和 setApplicationPalette 实现.
-    appTheme = systemTheme;
-
     if (qGuiApp) {
         initApplication(qGuiApp);
     } else {
@@ -124,6 +117,15 @@ void DGuiApplicationHelperPrivate::init()
 void DGuiApplicationHelperPrivate::initApplication(QGuiApplication *app)
 {
     D_Q(DGuiApplicationHelper);
+
+    if (!systemTheme) {
+        // 需要在QGuiApplication创建后再创建DPlatformTheme，否则DPlatformTheme无效.
+        // qGuiApp->platformFunction()会报警告，并返回nullptr.
+        systemTheme = new DPlatformTheme(0, q);
+        // 直接对应到系统级别的主题, 不再对外提供为某个单独程序设置主题的接口.
+        // 程序设置自身主题相关的东西皆可通过 setPaletteType 和 setApplicationPalette 实现.
+        appTheme = systemTheme;
+    }
 
     // 跟随application销毁
     qAddPostRoutine(staticCleanApplication);
@@ -159,11 +161,8 @@ void DGuiApplicationHelperPrivate::staticInitApplication()
     if (!_globalHelper.exists())
         return;
 
-    if (DGuiApplicationHelper *helper = _globalHelper->m_helper.load()) {
-        // systemTheme未创建时说明DGuiApplicationHelper还未初始化
-        if (helper->d_func()->systemTheme)
-            helper->d_func()->initApplication(qGuiApp);
-    }
+    if (DGuiApplicationHelper *helper = _globalHelper->m_helper.load())
+        helper->d_func()->initApplication(qGuiApp);
 }
 
 void DGuiApplicationHelperPrivate::staticCleanApplication()

--- a/src/private/dguiapplicationhelper_p.h
+++ b/src/private/dguiapplicationhelper_p.h
@@ -50,7 +50,7 @@ public:
 
     DGuiApplicationHelper::ColorType paletteType = DGuiApplicationHelper::UnknownType;
     // 系统级别的主题设置
-    DPlatformTheme *systemTheme;
+    DPlatformTheme *systemTheme = nullptr;
     QScopedPointer<DPalette> appPalette;
     // 获取QLocalSever消息的等待时间
     static int waitTime;


### PR DESCRIPTION
  DPlatformTheme is invalid when DGuiApplicationHelper::instance()
is called before QApplication constructed. it causes application theme can't follow change by control-center setted.

  for example:
```c++
DGuiApplicationHelper::instance();
QApplication a(argc, argv);
```
  it also reports warning info about `Must construct a QGuiApplication
before accessing a platform function` in QGuiApplication.

Log: 延迟DPlantfromTheme构造
Bug: https://pms.uniontech.com/bug-view-160485.html 
Influence: 先调用DGuiApplicationHelper::instance()可能有影响， 若先构造QApplication，与之前逻辑一致

Change-Id: I91297fb47c38c1ebb6d97f9c62915aa5d5557624