### PR TITLE
fix: Application theme can't follow change by system

### DIFF
--- a/src/private/dguiapplicationhelper_p.h
+++ b/src/private/dguiapplicationhelper_p.h
@@ -37,7 +37,7 @@ public:
 
     DGuiApplicationHelper::ColorType paletteType = DGuiApplicationHelper::UnknownType;
     // 系统级别的主题设置
-    DPlatformTheme *systemTheme;
+    DPlatformTheme *systemTheme = nullptr;
     QScopedPointer<DPalette> appPalette;
     // 获取QLocalSever消息的等待时间
     static int waitTime;


### PR DESCRIPTION
  DPlatformTheme is invalid when DGuiApplicationHelper::instance()
is called before QApplication constructed. it causes application theme can't follow change by control-center setted.

  for example:
```c++
DGuiApplicationHelper::instance();
QApplication a(argc, argv);
```
  it also reports warning info about `Must construct a QGuiApplication
before accessing a platform function` in QGuiApplication.

Log: 延迟DPlantfromTheme构造
Bug: https://pms.uniontech.com/bug-view-160485.html Influence: 先调用DGuiApplicationHelper::instance()可能有影响， 若先构造QApplication，与之前逻辑一致

Change-Id: I91297fb47c38c1ebb6d97f9c62915aa5d5557624