### PR TITLE
fix: filedrag do not send data in ll-box

### DIFF
--- a/src/filedrag/dfiledragserver.cpp
+++ b/src/filedrag/dfiledragserver.cpp
@@ -11,6 +11,7 @@
 #include <QUuid>
 #include <QDBusServer>
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
 #include <QDBusVariant>
 #include <QDBusError>
 #include <QCoreApplication>
@@ -170,7 +171,9 @@ DFileDragServerPrivate::~DFileDragServerPrivate()
 void DFileDragServerPrivate::writeMimeData(QMimeData *dest)
 {
     dest->setData(DND_MIME_SERVICE, QDBusConnection::sessionBus().baseService().toUtf8());
-    dest->setData(DND_MIME_PID, QString::number(QCoreApplication::applicationPid()).toUtf8());
+    // qApp->applicationPid() not right in ll-box
+    auto pid = QDBusConnection::sessionBus().interface()->servicePid(QDBusConnection::sessionBus().baseService());
+    dest->setData(DND_MIME_PID, QString::number(pid).toUtf8());
     dest->setData(DND_MIME_UUID, uuid.toString().toUtf8());
 }
 


### PR DESCRIPTION
qApp->applicationPid() 获取的是沙箱中的pid
QDBusConnectionInterface::servicePid 获取的是沙箱外的pid
改成相同的pid

Log: 修复v23无法拖拽邮件到桌面
Bug: https://pms.uniontech.com/bug-view-156601.html
Change-Id: I1e41a47e7f1e5030a33fff766b7fa35c675b7ae7