### PR TITLE
feat: Add Warning for unsupport Image format

### DIFF
--- a/src/util/ddciicon.cpp
+++ b/src/util/ddciicon.cpp
@@ -324,6 +324,8 @@ static QImage readImageData(const QByteArray &data, const QByteArray &format, qr
 
         if (!scaled)
             image = image.scaled(scaledSize, scaledSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    } else {
+        qWarning() << reader.errorString() << format;
     }
 
     return image;


### PR DESCRIPTION
  it causes paint error when load unsupport image format, we add
output some information.
  we can install package `qt5-image-formats-plugins`.
  it's need to support `webp` image for some dci icon.

Log: 添加dciicon图标解析失败导致无法绘制时的警告信息
Influence: none
Change-Id: Ief27263af5caa74c4a9f0436ebdf8759ea39bd82