### PR TITLE
feat: Moving loadTranslator from dtkwidget

### DIFF
--- a/include/kernel/dguiapplicationhelper.h
+++ b/include/kernel/dguiapplicationhelper.h
@@ -101,6 +101,8 @@ public:
 
     bool hasUserManual() const;
 
+    static bool loadTranslator(const QString &fileName, const QList<QString> &translateDirs, const QList<QLocale> &localeFallback);
+
 public Q_SLOTS:
     D_DECL_DEPRECATED_X("Plase use setPaletteType") void setThemeType(ColorType themeType);
     void setPaletteType(ColorType paletteType);


### PR DESCRIPTION
  moving implement of loadTranslator from dtkwidget,
  refact the code's logic.

Log: 加载翻译功能移至dtkgui，以便供dtkdeclarative使用
Bug: https://pms.uniontech.com/bug-view-157977.html
Influence: qml相关应用没有加载翻译
Change-Id: I75483320cbb6f8a1378cb8a93f00da3d8abfc26f