### PR TITLE
fix: edit clearbutton pressed style incorrect

### DIFF
--- a/src/util/icons/deepin-theme-plugin-icons.qrc
+++ b/src/util/icons/deepin-theme-plugin-icons.qrc
@@ -48,6 +48,7 @@
     </qresource>
     <qresource prefix="/icons/deepin/builtin/light">
         <file alias="icons/button_edit-clear_30px.svg/normal.svg">icons/light/edit-clear_30px.svg</file>
+        <file alias="icons/button_edit-clear_30px.svg/active.svg">icons/light/edit-clear_active_30px.svg</file>
         <file alias="icons/button_edit-clear_30px.svg/selected.svg">icons/light/edit-clear_press_30px.svg</file>
         <file alias="icons/button_voice_30px.svg/normal.svg">icons/light/button_voice_30px.svg</file>
         <file alias="icons/button_voice_30px.svg/selected.svg">icons/light/button_voice_press_30px.svg</file>
@@ -58,6 +59,7 @@
     </qresource>
     <qresource prefix="/icons/deepin/builtin/dark">
         <file alias="icons/button_edit-clear_30px.svg/normal.svg">icons/dark/edit-clear_30px.svg</file>
+        <file alias="icons/button_edit-clear_30px.svg/active.svg">icons/dark/edit-clear_active_30px.svg</file>
         <file alias="icons/button_edit-clear_30px.svg/selected.svg">icons/dark/edit-clear_press_30px.svg</file>
         <file alias="icons/button_voice_30px.svg/normal.svg">icons/dark/button_voice_30px.svg</file>
         <file alias="icons/button_voice_30px.svg/selected.svg">icons/dark/button_voice_press_30px.svg</file>

--- a/src/util/icons/icons/dark/edit-clear_active_30px.svg
+++ b/src/util/icons/icons/dark/edit-clear_active_30px.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="30" height="30" viewBox="0 0 30 30">
+  <defs>
+    <linearGradient id="button_clear_dark_press-c" x1="50%" x2="50%" y1="0%" y2="95.653%">
+      <stop offset="0%" stop-color="#242424"/>
+      <stop offset="100%" stop-color="#282828"/>
+    </linearGradient>
+    <circle id="button_clear_dark_press-b" cx="11" cy="11" r="11"/>
+    <filter id="button_clear_dark_press-a" width="163.6%" height="163.6%" x="-31.8%" y="-22.7%" filterUnits="objectBoundingBox">
+      <feOffset dy="2" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="2"/>
+      <feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.05 0"/>
+    </filter>
+  </defs>
+  <g fill="none" fill-rule="evenodd" transform="translate(4 4)">
+    <use fill="#000" filter="url(#button_clear_dark_press-a)" xlink:href="#button_clear_dark_press-b"/>
+    <use fill="#000" fill-opacity=".08" xlink:href="#button_clear_dark_press-b"/>
+    <circle cx="11" cy="11" r="10.5" fill="url(#button_clear_dark_press-c)" stroke="#FFF" stroke-linejoin="square" stroke-opacity=".03"/>
+    <path fill="#0081FF" d="M7.64644661,7.64643911 C7.84170876,7.45117696 8.15829124,7.45117696 8.35355339,7.64643911 L8.35355339,7.64643911 L11,10.2929925 L13.6464466,7.64643911 C13.820013,7.47287276 14.0894374,7.45358761 14.2843055,7.58858366 L14.3535534,7.64643911 C14.5488155,7.84170126 14.5488155,8.15828374 14.3535534,8.35354589 L14.3535534,8.35354589 L11.707,10.9999925 L14.3535534,13.6464391 C14.5271197,13.8200055 14.5464049,14.0894299 14.4114088,14.284298 L14.3535534,14.3535459 C14.1582912,14.548808 13.8417088,14.548808 13.6464466,14.3535459 L13.6464466,14.3535459 L11,11.7069925 L8.35355339,14.3535459 C8.17998704,14.5271122 7.91056264,14.5463974 7.7156945,14.4114013 L7.64644661,14.3535459 C7.45118446,14.1582837 7.45118446,13.8417013 7.64644661,13.6464391 L7.64644661,13.6464391 L10.293,10.9999925 L7.64644661,8.35354589 C7.47288026,8.17997954 7.45359511,7.91055514 7.58859116,7.715687 Z"/>
+  </g>
+</svg>

--- a/src/util/icons/icons/light/edit-clear_active_30px.svg
+++ b/src/util/icons/icons/light/edit-clear_active_30px.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="30" height="30" viewBox="0 0 30 30">
+  <defs>
+    <circle id="button_clear_press-b" cx="11" cy="11" r="11"/>
+    <filter id="button_clear_press-a" width="209.1%" height="209.1%" x="-54.5%" y="-36.4%" filterUnits="objectBoundingBox">
+      <feMorphology in="SourceAlpha" operator="dilate" radius="1" result="shadowSpreadOuter1"/>
+      <feOffset dy="4" in="shadowSpreadOuter1" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="3"/>
+      <feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.05 0"/>
+    </filter>
+    <linearGradient id="button_clear_press-e" x1="50%" x2="50%" y1="0%" y2="95.653%">
+      <stop offset="0%" stop-color="#BCC4D0"/>
+      <stop offset="100%" stop-color="#CDD6E0"/>
+    </linearGradient>
+    <circle id="button_clear_press-d" cx="11" cy="11" r="11"/>
+    <filter id="button_clear_press-c" width="163.6%" height="163.6%" x="-31.8%" y="-22.7%" filterUnits="objectBoundingBox">
+      <feOffset dy="2" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="2"/>
+      <feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"/>
+      <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.05 0"/>
+    </filter>
+  </defs>
+  <g fill="none" fill-rule="evenodd" transform="translate(4 4)">
+    <use fill="#000" filter="url(#button_clear_press-a)" xlink:href="#button_clear_press-b"/>
+    <circle cx="11" cy="11" r="11.5" fill="#FFF" stroke="#000" stroke-opacity=".02"/>
+    <use fill="#000" filter="url(#button_clear_press-c)" xlink:href="#button_clear_press-d"/>
+    <circle cx="11" cy="11" r="10.5" fill="url(#button_clear_press-e)" stroke="#000" stroke-linejoin="square" stroke-opacity=".03"/>
+    <path fill="#0081FF" d="M7.64644661,7.64643911 C7.84170876,7.45117696 8.15829124,7.45117696 8.35355339,7.64643911 L8.35355339,7.64643911 L11,10.2929925 L13.6464466,7.64643911 C13.820013,7.47287276 14.0894374,7.45358761 14.2843055,7.58858366 L14.3535534,7.64643911 C14.5488155,7.84170126 14.5488155,8.15828374 14.3535534,8.35354589 L14.3535534,8.35354589 L11.707,10.9999925 L14.3535534,13.6464391 C14.5271197,13.8200055 14.5464049,14.0894299 14.4114088,14.284298 L14.3535534,14.3535459 C14.1582912,14.548808 13.8417088,14.548808 13.6464466,14.3535459 L13.6464466,14.3535459 L11,11.7069925 L8.35355339,14.3535459 C8.17998704,14.5271122 7.91056264,14.5463974 7.7156945,14.4114013 L7.64644661,14.3535459 C7.45118446,14.1582837 7.45118446,13.8417013 7.64644661,13.6464391 L7.64644661,13.6464391 L10.293,10.9999925 L7.64644661,8.35354589 C7.47288026,8.17997954 7.45359511,7.91055514 7.58859116,7.715687 Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
QLineEditIconButton(Qt 5.15) get pixmap from Active state instead of Selected state when button is down
add active state pixmap (note that dstyle  will fill 10% opacity black or white on active state)

Bug: https://pms.uniontech.com/bug-view-172425.html
Incluence: QLineEdit clearbutton
Log: none
Change-Id: I182e6ec7b68bd251a3eb935616d2e3f6393d6676