### PR TITLE
fix: 包含 href 特性的 svg 图标无法显示

### DIFF
--- a/src/util/dsvgrenderer.cpp
+++ b/src/util/dsvgrenderer.cpp
@@ -25,6 +25,7 @@
 #include <QDebug>
 #include <QGuiApplication>
 #include <QLibrary>
+#include <QXmlStreamReader>
 
 DCORE_USE_NAMESPACE
 
@@ -263,12 +264,53 @@ QImage DSvgRenderer::toImage(const QSize sz, const QString &elementId) const
     return d->getImage(sz, elementId);
 }
 
+static QByteArray updateXmlAttribute(const QString &contents)
+{
+    QByteArray data;
+    QXmlStreamWriter writer(&data);
+    QXmlStreamReader reader(contents);
+    while(reader.readNext() != QXmlStreamReader::Invalid && !reader.atEnd()) {
+        if (reader.tokenType() != QXmlStreamReader::StartElement ||
+                !reader.attributes().hasAttribute("href")) {
+            writer.writeCurrentToken(reader);
+            continue;
+        }
+
+        for (const auto &nd : reader.namespaceDeclarations())
+            writer.writeNamespace(nd.namespaceUri().toString(), nd.prefix().toString());
+
+        writer.writeStartElement(reader.namespaceUri().toString(), reader.name().toString());
+
+        for (const auto &attr : reader.attributes()) {
+            if (attr.name() == "href") {
+                writer.writeAttribute("xlink:href", attr.value().toString());
+                continue;
+            }
+            writer.writeAttribute(attr);
+        }
+    }
+
+    return data;
+}
+
+QByteArray format(const QByteArray &contents)
+{
+    QXmlStreamReader reader(contents);
+    while (reader.readNextStartElement()) {
+        if (reader.attributes().hasAttribute("href"))
+            return updateXmlAttribute(contents);
+    }
+
+    return contents;
+}
+
 bool DSvgRenderer::load(const QString &filename)
 {
     QFile file(filename);
 
     if (file.open(QIODevice::ReadOnly)) {
-        return load(file.readAll());
+        // TODO: if `href` attribute is adapted after librsvg upgrade revert me
+        return load(format(file.readAll()));
     }
 
     return false;


### PR DESCRIPTION
librsvg2 对 SVG2 的 href 解析有问题，需要改成 xlink:href 规避
当前是临时规避方案，如果后续 librsvg2 升级修复这个问题，可以 revert
https://www.w3.org/TR/2018/CR-SVG2-20181004/types.html#InterfaceSVGURIReference

Task: https://pms.uniontech.com/task-view-218689.html
Influence: 包含href的svg图标
Log: 修复包含href的svg图标无法显示的问题
Change-Id: Idaf0ca9519153cd8fe217aeaaeab250b18f35393