### PR TITLE
chore: fix linking error

### DIFF
--- a/misc/DtkGuiConfig.cmake.in
+++ b/misc/DtkGuiConfig.cmake.in
@@ -6,7 +6,8 @@ set(DtkGui_TOOL_DIRS "@PACKAGE_TOOL_INSTALL_DIR@")
 
 include(CMakeFindDependencyMacro)
 find_dependency(DtkCore REQUIRED)
-set(DtkGui_LIBRARIES dtkgui ${DtkCore_LIBRARIES})
+find_library(DtkGui_LIBRARIES dtkgui ${DtkGui_LIBRARY_DIRS})
+set(DtkGui_LIBRARIES ${DtkGui_LIBRARIES} ${DtkCore_LIBRARIES})
 
 include_directories("${DtkGui_INCLUDE_DIRS}")
 


### PR DESCRIPTION
DtkGuiConfig.cmake will always find the library under system library path. This will cause a linking error when you want to use the version deployed by yourself. Fix that by appending the path prefix.

Log: fix DtkGuiConfig.cmake.in
Influence: DtkGuiConfig.cmake.in