### PR TITLE
fix: AreadList metaType override

### DIFF
--- a/src/dbus/xeventmonitor_interface.cpp
+++ b/src/dbus/xeventmonitor_interface.cpp
@@ -6,10 +6,43 @@
 
 static void registerAreaListMetaType()
 {
-    qRegisterMetaType<AreaList>("AreaList");
-    qDBusRegisterMetaType<AreaList>();
+    // FIX 取消注册qRegisterMetaType，会影响 dock 使用 RegisterAreas dbus接口
+    // 因为 libdframeworkdbus-dev 也会注册 "AreaList" 为 MonitorRect
+//    qRegisterMetaType<AreaList>("AreaList");
+    qDBusRegisterMetaType<ComDeepinApiXEventMonitorInterface::AreaList>();
 }
 Q_CONSTRUCTOR_FUNCTION(registerAreaListMetaType);
+
+QDBusArgument &operator<<(QDBusArgument &a, const ComDeepinApiXEventMonitorInterface::AreaList &rects)
+{
+    // com.deepin.api.XEventMonitor.RegisterAreas
+    // (Array of [Struct of (Int32, Int32, Int32, Int32)] areas, Int32 flag)
+    // use [x1, y1, x2, y2] instead of [x1, y1, w, h]
+    a.beginArray(qRegisterMetaType<QRect>());
+    for (const auto &r : rects) {
+        a.beginStructure();
+        a << r.left() << r.top() << r.right() << r.bottom();
+        a.endStructure();
+    }
+    a.endArray();
+    return a;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &a, ComDeepinApiXEventMonitorInterface::AreaList &rects)
+{
+    a.beginArray();
+    rects.clear();
+    int x1 = 0 , y1 = 0 , x2 = 0 , y2 = 0 ;
+    while (!a.atEnd()) {
+        a.beginStructure();
+        a >> x1 >> y1 >> x2 >> y2;
+        a.endStructure();
+
+        rects.append(QRect(QPoint(x1, y1), QPoint(x2, y2)));
+    }
+    a.endArray();
+    return a;
+}
 
 ComDeepinApiXEventMonitorInterface::ComDeepinApiXEventMonitorInterface(const QString &service, const QString &path,
                                                                        const char *interface, QObject *parent,

--- a/src/dbus/xeventmonitor_interface.h
+++ b/src/dbus/xeventmonitor_interface.h
@@ -14,11 +14,11 @@
 #include <QtCore/QVariant>
 #include <QtDBus/QtDBus>
 
-typedef QList<QRect> AreaList;
 class ComDeepinApiXEventMonitorInterface: public QDBusAbstractInterface
 {
     Q_OBJECT
 public:
+    typedef QList<QRect> AreaList;
     ComDeepinApiXEventMonitorInterface(const QString &service, const QString &path, const char *interface, QObject *parent = nullptr,
                                        const QDBusConnection &con = QDBusConnection::sessionBus());
 


### PR DESCRIPTION
qRegisterMetaType<AreaList>("AreaList");
覆盖导致dock使用接口出现位置异常
https://github.com/linuxdeepin/dde-qt-dbus-factory/blob/cc2a09558b78be6a975e4c1fff38bc4eaa814a59/libdframeworkdbus/types/arealist.cpp#L35

Bug: https://pms.uniontech.com/bug-view-175747.html
Log: none
Influence: dock hide and show
Change-Id: Ie10bd436ddaa66e0477b5db40d6e36fbea2d0733