### PR TITLE
feat: Add SizeMode support

### DIFF
--- a/docs/src/dguiapplicationhelper.zh_CN.dox
+++ b/docs/src/dguiapplicationhelper.zh_CN.dox
@@ -1,16 +1,50 @@
 /*!
 @~chinese
+@file dguiapplicationhelper.h
+
+@class Dtk::Gui::DGuiApplicationHelper
+@ingroup dtkgui
+@brief DGuiApplicationHelper类提供了一个gui应用程序的应用帮助类，可提供widget和declarative的
+公共gui功能，例如调色板、字体、主题等功能。
+@details
+
+@enum Dtk::Gui::DGuiApplicationHelper::SizeMode
+@brief 控件大小模式枚举包含 dtk支持的控件大小模式种类.
+| **值**      | **含义**               |
+|:-----------:|:---------------------:|
+| NormalMode   | 普通模式，为默认模式 |
+| CompactMode  | 紧凑模式 |
 
 @fn void DGuiApplicationHelper::newProcessInstance(qint64 pid, const QStringList &arguments)
 @brief 通知新进程的信息。
-
+@details
 单例程序情况下，尝试启动新的程序实例将触发此信号，以便获取所传入的参数列表等信息，来进行进一步处理。
 
 @param pid 进程 ID.
 @param arguments 启动进程时所传入的参数列表.
 
+@fn DGuiApplicationHelper::SizeMode DGuiApplicationHelper::sizeMode() const
+@brief 当前应用的控件大小模式。
+@details
+- 若应用没有设置控件大小模式，则跟随系统的控件大小模式
+- 用户也可以设置环境变量 D_DTK_SIZEMODE 来影响应用的大小模式的支持，`D_DTK_SIZEMODE=1`为指定为普通模式，
+当应用没有显示设置控件大小模式，则会采用普通模式。
+- 优先级为 `DGuiApplicationHelper::setSizeMode` > `D_DTK_SIZEMODE` > `System's SizeMode`。
+
+@fn void DGuiApplicationHelper::setSizeMode(const DGuiApplicationHelper::SizeMode sizeMode)
+@brief 设置应用控件大小模式，应用使用的为此模式，不再响应系统的控件大小模式。
+@param sizeMode 需要设置的控件大小模式.
+
+@fn void DGuiApplicationHelper::resetSizeMode()
+@brief 重置设置应用控件大小模式，跟随系统的控件大小模式。
+
+@fn static inline bool DGuiApplicationHelper::isCompactMode()
+@brief 当前控件大小模式是否为紧凑模式。
+
 @fn void DGuiApplicationHelper::applicationPaletteChanged()
 @brief 通知调色板对象的改变。
-
 @sa windowPalette()
+
+@fn void DGuiApplicationHelper::sizeModeChanged(DGuiApplicationHelper::SizeMode sizeMode)
+@brief 通知控件大小模式发生改变。
 */

--- a/docs/src/dplatformtheme.zh_CN.dox
+++ b/docs/src/dplatformtheme.zh_CN.dox
@@ -1,0 +1,13 @@
+/*!
+@~chinese
+@file dplatformtheme.h
+
+@class Dtk::Gui::DPlatformTheme
+@ingroup dtkgui
+@brief DPlatformTheme类提供了一个应用程序的主题配置管理类,可以在外部控制应用的默认主题行为，
+达到个性化主题的设置，所有的设置是实时响应的。
+
+@property DPlatformTheme::sizeMode
+@brief 从配置中获取当前控件大小模式
+
+*/

--- a/include/kernel/dguiapplicationhelper.h
+++ b/include/kernel/dguiapplicationhelper.h
@@ -41,6 +41,12 @@ public:
     };
     Q_ENUM(SingleScope)
 
+    enum SizeMode {
+        NormalMode,
+        CompactMode
+    };
+    Q_ENUM(SizeMode)
+
     enum Attribute {
         UseInactiveColorGroup    = 1 << 0,
         ColorCompositing         = 1 << 1,
@@ -109,12 +115,21 @@ public Q_SLOTS:
     void handleHelpAction();
     static void openUrl(const QString &url);
 
+    DGuiApplicationHelper::SizeMode sizeMode() const;
+    void setSizeMode(const DGuiApplicationHelper::SizeMode mode);
+    void resetSizeMode();
+    static inline bool isCompactMode()
+    {
+        return instance()->sizeMode() == DGuiApplicationHelper::CompactMode;
+    }
+
 Q_SIGNALS:
     void themeTypeChanged(ColorType themeType);
     void paletteTypeChanged(ColorType paletteType);
     void newProcessInstance(qint64 pid, const QStringList &arguments);
     void fontChanged(const QFont &font);
     void applicationPaletteChanged();
+    void sizeModeChanged(DGuiApplicationHelper::SizeMode sizeMode);
 
 protected:
     explicit DGuiApplicationHelper();
@@ -122,6 +137,7 @@ protected:
 
 private:
     D_PRIVATE_SLOT(void _q_initApplicationTheme(bool))
+    D_PRIVATE_SLOT(void _q_sizeModeChanged(int))
     friend class _DGuiApplicationHelper;
 };
 

--- a/include/kernel/dplatformtheme.h
+++ b/include/kernel/dplatformtheme.h
@@ -64,6 +64,8 @@ class DPlatformTheme : public DNativeSettings
     Q_PROPERTY(QColor lightLively READ lightLively WRITE setLightLively NOTIFY lightLivelyChanged)
     Q_PROPERTY(QColor darkLively READ darkLively WRITE setDarkLively NOTIFY darkLivelyChanged)
     Q_PROPERTY(QColor frameBorder READ frameBorder WRITE setFrameBorder NOTIFY frameBorderChanged)
+    // DSizeMode
+    Q_PROPERTY(int sizeMode READ sizeMode NOTIFY sizeModeChanged)
 
 public:
     explicit DPlatformTheme(quint32 window, QObject *parent = nullptr);
@@ -128,6 +130,8 @@ public:
     QColor frameBorder() const;
 
     int dotsPerInch(const QString &screenName = QString()) const;
+
+    int sizeMode() const;
 
 public Q_SLOTS:
     void setCursorBlinkTime(int cursorBlinkTime);
@@ -220,6 +224,7 @@ Q_SIGNALS:
     void frameBorderChanged(QColor frameBorder);
     void dotsPerInchChanged(const QString &screen, int dpi);
     void windowRadiusChanged(int r);
+    void sizeModeChanged(int sizeMode);
 
 private:
     friend class DPlatformThemePrivate;

--- a/src/kernel/dplatformtheme.cpp
+++ b/src/kernel/dplatformtheme.cpp
@@ -618,6 +618,17 @@ int DPlatformTheme::dotsPerInch(const QString &screenName) const
     return ok ? dpi : -1;
 }
 
+/*!
+  \property DPlatformTheme::sizeMode
+  \brief This property holds the sizeMode of the system's SizeMode.
+ */
+int DPlatformTheme::sizeMode() const
+{
+    D_DC(DPlatformTheme);
+    QVariant value = d->theme->getSetting(QByteArrayLiteral("DTK/SizeMode"));
+    return value.toInt();
+}
+
 void DPlatformTheme::setCursorBlinkTime(int cursorBlinkTime)
 {
     D_D(DPlatformTheme);

--- a/src/private/dguiapplicationhelper_p.h
+++ b/src/private/dguiapplicationhelper_p.h
@@ -31,6 +31,8 @@ public:
     static void staticCleanApplication();
     DPlatformTheme *initWindow(QWindow *window) const;
     void _q_initApplicationTheme(bool notifyChange = false);
+    void _q_sizeModeChanged(int mode);
+    DGuiApplicationHelper::SizeMode fetchSizeMode(bool *isSystemSizeMode = nullptr) const;
     void notifyAppThemeChanged();
     // 返回程序是否自定义了调色板
     inline bool isCustomPalette() const;
@@ -42,6 +44,8 @@ public:
     // 获取QLocalSever消息的等待时间
     static int waitTime;
     static DGuiApplicationHelper::Attributes attributes;
+    DGuiApplicationHelper::SizeMode systemSizeMode = DGuiApplicationHelper::NormalMode;
+    DGuiApplicationHelper::SizeMode explicitSizeMode;
 
 private:
     // 应用程序级别的主题设置


### PR DESCRIPTION
  enable SizeMode support by default.
  user can set environment `D_DTK_SIZEMODE` to set
SizeMode support.
  application can set SizeMode by `setSizeMode` explicitly.

Log: 支持紧凑模式切换
Task: https://pms.uniontech.com/task-view-227385.html
Influence: none
Change-Id: I2eefe254f9bbf380d9ab133c4eb0caa979ed1356