### PR TITLE
fix: fix-dark-theme not work on link file

### DIFF
--- a/tools/dci-icon-theme/README.md
+++ b/tools/dci-icon-theme/README.md
@@ -3,7 +3,7 @@
 Usage: dci-icon-theme [options] ~/dci-png-icons
 
 Options:
-  -m, --match <wirdcard palette>  Give wirdcard rules on search icon files,
+  -m, --match <wildcard palette>  Give wildcard rules on search icon files,
                                   Each eligible icon will be packaged to a dci
                                   file, If the icon have the dark mode, it needs
                                   to store the dark icon file at "dark/"


### PR DESCRIPTION
--fix-dark-theme only copy linktarget file to ouputput dir. record link-target map and makelink after fix job
update version to 0.0.2

Log: none
Influence: none
Change-Id: I9100c98107551eb002656e34937a8524075743bc