### PR TITLE
chore: change GTest::gtest for compatibility

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     Qt5::Test
     Dtk::Core
     PkgConfig::librsvg
-    GTest::gtest
+    GTest::GTest
     gmock
     pthread
     m


### PR DESCRIPTION
Change GTest::gtest to GTest::GTest for backward compatibility.

Log: change GTest::gtest to GTest::GTest