### PR TITLE
chore: option to use KIconThemes instead of Qt5XdgIconLoader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ project(DtkGui
 set(LIB_NAME dtkgui)
 
 include(GNUInstallDirs)
+include(FeatureSummary)
+include(CMakeDependentOption)
 include(CMakePackageConfigHelpers)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_CXX_STANDARD 11)
@@ -19,7 +21,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Set build option
-option(DTK_DISABLE_LIBXDG "Disable libxdg" OFF)
+option(DTK_DISABLE_ICON_ENGINE_PROXY "Disable icon engine, use QIcon::fromTheme() as possible fallback" OFF)
+cmake_dependent_option(DTK_DISABLE_LIBXDG "If icon engine proxy is used, prefer KIconEngine instead of using libqxdg" OFF "NOT DTK_DISABLE_ICON_ENGINE_PROXY" OFF)
 option(DTK_DISABLE_LIBRSVG "Disable librsvg" OFF)
 option(DTK_DISABLE_EX_IMAGE_FORMAT "Disable libraw and freeimage" OFF)
 set(BUILD_DOCS ON CACHE BOOL "Generate doxygen-based documentation")
@@ -132,3 +135,5 @@ add_subdirectory(examples)
 if (BUILD_DOCS)
   add_subdirectory(docs)
 endif ()
+
+feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,10 +47,12 @@ if(NOT DTK_DISABLE_EX_IMAGE_FORMAT AND EX_IMAGE_FORMAT_LIBS_FOUND)
     )
 endif()
 
-if(NOT DTK_DISABLE_LIBXDG)
-    target_link_libraries(${LIB_NAME} PRIVATE
-        Qt5XdgIconLoader
-    )
+if(NOT DTK_DISABLE_ICON_ENGINE_PROXY)
+    if(DTK_DISABLE_LIBXDG)
+        target_link_libraries(${LIB_NAME} PRIVATE KF5::IconThemes)
+    else()
+        target_link_libraries(${LIB_NAME} PRIVATE Qt5XdgIconLoader)
+    endif()
 endif()
 
 set_target_properties(${LIB_NAME} PROPERTIES

--- a/src/util/util.cmake
+++ b/src/util/util.cmake
@@ -1,20 +1,28 @@
-if(NOT DTK_DISABLE_LIBXDG)
-    find_package(qt5xdgiconloader)
+set(UTIL_PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/private/dbuiltiniconengine_p.h
+  ${CMAKE_CURRENT_LIST_DIR}/private/dbuiltiniconengine.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/private/dimagehandlerlibs_p.h
+)
+
+if(NOT DTK_DISABLE_ICON_ENGINE_PROXY)
+  if(NOT DTK_DISABLE_LIBXDG)
+    find_package(qt5xdgiconloader REQUIRED)
     add_definitions(-DXDG_ICON_VERSION_MAR=${qt5xdgiconloader_VERSION_MAJOR})
-    set(UTIL_PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/private/xdgiconproxyengine_p.h
-        ${CMAKE_CURRENT_LIST_DIR}/private/xdgiconproxyengine.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/private/dbuiltiniconengine_p.h
-        ${CMAKE_CURRENT_LIST_DIR}/private/dbuiltiniconengine.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/private/dimagehandlerlibs_p.h
+    list(APPEND UTIL_PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}/private/xdgiconproxyengine_p.h
+      ${CMAKE_CURRENT_LIST_DIR}/private/xdgiconproxyengine.cpp
     )
-else()
-    add_definitions(-DDTK_DISABLE_LIBXDG)
-    set(UTIL_PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/private/dbuiltiniconengine_p.h
-        ${CMAKE_CURRENT_LIST_DIR}/private/dbuiltiniconengine.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/private/dimagehandlerlibs_p.h
-    )
+  else()
+    find_package(KF5IconThemes REQUIRED)
+  endif()
+endif()
+
+if(DTK_DISABLE_ICON_ENGINE_PROXY)
+  add_definitions(-DDTK_DISABLE_ICON_ENGINE_PROXY)
+endif()
+
+if(DTK_DISABLE_LIBXDG)
+  add_definitions(-DDTK_DISABLE_LIBXDG)
 endif()
 
 if(DTK_DISABLE_EX_IMAGE_FORMAT OR NOT EX_IMAGE_FORMAT_LIBS_FOUND)


### PR DESCRIPTION
提供选项，使用 KIconThemes 替代 Qt5XdgIconLoader。

目前加了一些 ifdef 去判断用哪个，但我们还有必要保留使用 Qt5XdgIconLoader 的实现吗？

相关：

- https://github.com/linuxdeepin/qt5integration/pull/129