### PR TITLE
fix: Inconsistent themeType when setThemeType

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -1700,6 +1700,7 @@ void DGuiApplicationHelper::setPaletteType(DGuiApplicationHelper::ColorType pale
 {
     D_D(DGuiApplicationHelper);
 
+    d->initPaletteType();
     d->setPaletteType(paletteType, true);
 }
 


### PR DESCRIPTION
  When we call setThemeType to DarkType, it will sync DConfig's
themeType, and reset it to UnknowType, and it cause ut failed.