### PR TITLE
fix: App blocked by hasUserManual in live system

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -1540,7 +1540,8 @@ bool DGuiApplicationHelper::hasUserManual() const
         return hasManual;
 
     QDBusConnection conn = QDBusConnection::sessionBus();
-    if (!conn.isConnected()) {
+    if (!conn.isConnected() ||
+        !conn.interface()->isServiceRegistered("com.deepin.Manual.Search")) {
         static LoadManualServiceWorker *manualWorker = new LoadManualServiceWorker;
         manualWorker->checkManualServiceWakeUp();
 


### PR DESCRIPTION
  Maunal dbus service isn't registed in live system firstly, we
should wakeup it instead of blocking UI.
  It may be cause app of `longlong` hasn't Manual when click menu
to show Maunal firstly.

Bug: https://pms.uniontech.com/bug-view-197713/.html
Log: 解决在live系统中，帮助手册dbus调用导致应用阻塞