### PR TITLE
chore: ignore doxygen-theme folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ dtkgui.pc
 DtkGuiConfig.cmake
 asan.*
 Testing
+
+# Ignore Doxygen theme files
+docs/doxygen-theme/


### PR DESCRIPTION
chore: ignore doxygen-theme folder

Log: 修复编译时加上BUILD_THEME宏后，自动拉取doxygen-theme导致git管理的项目产生污染

Task: https://github.com/linuxdeepin/dtk/issues/99