### PR TITLE
refactor: Move dotsPerInch from normal function to slots

### DIFF
--- a/include/kernel/dplatformtheme.h
+++ b/include/kernel/dplatformtheme.h
@@ -134,8 +134,6 @@ public:
     QColor frameBorder() const;
 #endif
 
-    int dotsPerInch(const QString &screenName = QString()) const;
-
     int sizeMode() const;
     int scrollBarPolicy() const;
 
@@ -184,6 +182,7 @@ public Q_SLOTS:
     void setFrameBorder(const QColor &frameBorder);
 #endif
 
+    int dotsPerInch(const QString &screenName = QString()) const;
     void setDotsPerInch(const QString &screenName, int dpi);
     void setWindowRadius(int windowRadius);
 


### PR DESCRIPTION
  It exports to qt meta system for qml.
  and it doesn't break ABI compatibility depend on
https://community.kde.org/Policies/Binary_Compatibility_Issues_With_C%2B%2B#Using_signals_instead_of_virtual_functions
