### PR TITLE
fix(build): DIconTheme ut failed 

### DIFF
--- a/src/util/dicontheme.cpp
+++ b/src/util/dicontheme.cpp
@@ -113,7 +113,11 @@ bool DIconTheme::isBuiltinIcon(const QIcon &icon)
 {
     if (icon.isNull())
         return false;
-    return typeid(*const_cast<QIcon&>(icon).data_ptr()->engine) == typeid(DBuiltinIconEngine);
+    QIconEngine *engine = const_cast<QIcon &>(icon).data_ptr()->engine;
+    if (auto proxyEngine = dynamic_cast<DIconProxyEngine *>(engine))
+        return !proxyEngine->proxyKey().compare("DBuiltinIconEngine");
+
+    return dynamic_cast<DBuiltinIconEngine *>(engine);
 }
 
 bool DIconTheme::isXdgIcon(const QIcon &icon)
@@ -123,7 +127,12 @@ bool DIconTheme::isXdgIcon(const QIcon &icon)
 #else
     if (icon.isNull())
         return false;
-    return typeid(*const_cast<QIcon&>(icon).data_ptr()->engine) == typeid(XdgIconProxyEngine);
+
+    QIconEngine *engine = const_cast<QIcon &>(icon).data_ptr()->engine;
+    if (auto proxyEngine = dynamic_cast<DIconProxyEngine *>(engine))
+        return !proxyEngine->proxyKey().compare("XdgIconProxyEngine");
+
+    return dynamic_cast<XdgIconProxyEngine *>(engine);
 #endif
 }
 

--- a/src/util/private/diconproxyengine.cpp
+++ b/src/util/private/diconproxyengine.cpp
@@ -50,7 +50,7 @@ static inline QIconEngine *createDciIconEngine(const QString &iconName)
 #ifndef DTK_DISABLE_LIBXDG
 static inline QIconEngine *createXdgProxyIconEngine(const QString &iconName)
 {
-    QIconEngine *iconEngine = new XdgIconLoaderEngine(iconName);
+    QIconEngine *iconEngine = new XdgIconProxyEngine(new XdgIconLoaderEngine(iconName));
     if (iconEngine->isNull()) {
         delete iconEngine;
         return nullptr;
@@ -170,6 +170,12 @@ const
 #endif
 {
     return m_iconName;
+}
+
+QString DIconProxyEngine::proxyKey()
+{
+    ensureEngine();
+    return m_iconEngine ? m_iconEngine->key() : QString();
 }
 
 void DIconProxyEngine::virtual_hook(int id, void *data)

--- a/src/util/private/diconproxyengine_p.h
+++ b/src/util/private/diconproxyengine_p.h
@@ -33,6 +33,8 @@ public:
     QString iconName() const override;
 #endif
     inline QString themeName() const { return m_iconThemeName; }
+
+    QString proxyKey();
 private:
     void virtual_hook(int id, void *data) override;
 


### PR DESCRIPTION
DIconTheme::createIconEngine always create DIconProxyEngine so DIconTheme::isBuiltinIcon && DIconTheme::isXdgIcon failed add DIconProxyEngine::proxyKey() to get proxy iconengine's key