### PR TITLE
fix: DFileDragClient::serverDestroyed nerver emit

### DIFF
--- a/src/filedrag/dfiledragclient.cpp
+++ b/src/filedrag/dfiledragclient.cpp
@@ -68,6 +68,7 @@ void DDndClientSignalRelay::stateChanged(QString uuid, int state)
 void DDndClientSignalRelay::serverDestroyed(QString uuid)
 {
     if (DFileDragClientPrivate::connectionmap.contains(uuid)) {
+        Q_EMIT DFileDragClientPrivate::connectionmap[uuid]->serverDestroyed();
         DFileDragClientPrivate::connectionmap[uuid]->deleteLater();
         DFileDragClientPrivate::connectionmap.remove(uuid);
     }

--- a/src/filedrag/dfiledragserver.cpp
+++ b/src/filedrag/dfiledragserver.cpp
@@ -102,6 +102,7 @@ DFileDragServer::DFileDragServer(QObject *parent)
 DFileDragServer::~DFileDragServer()
 {
     D_D(DFileDragServer);
+    Q_EMIT d->dbusif->serverDestroyed(d->uuid.toString());
     DFileDragServerPrivate::servermap.remove(d->uuid.toString());
 }
 
@@ -165,7 +166,6 @@ DFileDragServerPrivate::DFileDragServerPrivate(DFileDragServer *q)
 
 DFileDragServerPrivate::~DFileDragServerPrivate()
 {
-    Q_EMIT dbusif->serverDestroyed(uuid.toString());
 }
 
 void DFileDragServerPrivate::writeMimeData(QMimeData *dest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ include(../src/dbus/dbus.cmake)
 include(../src/kernel/kernel.cmake)
 include(../src/util/util.cmake)
 include(../src/private/private.cmake)
+include(../src/filedrag/dfiledrag.cmake)
 
 file(GLOB test_SRC
     res.qrc
@@ -20,6 +21,7 @@ add_executable(${BIN_NAME}
     ${kernel_SRC}
     ${util_SRC}
     ${private_SRC}
+    ${filedrag_SRC}
     ${test_SRC}
 )
 

--- a/tests/src/ut_dfiledrag.cpp
+++ b/tests/src/ut_dfiledrag.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "test.h"
+#include "dfiledragcommon_p.h"
+#include "dfiledrag.h"
+#include "dfiledragserver.h"
+#include "dfiledragclient.h"
+
+#include <QMimeData>
+#include <QtDBus>
+#include <QSignalSpy>
+#include <QTest>
+#include <QScopeGuard>
+DGUI_USE_NAMESPACE
+
+TEST(ut_DFileDrag, filedrag)
+{
+    qRegisterMetaType<DFileDragState>("DFileDragState");
+    QObject source;
+    auto s = new DFileDragServer();
+    QMimeData *m = new QMimeData();
+    DFileDrag *drag = new DFileDrag(&source, s);
+    drag->setMimeData(m);
+
+    QScopeGuard guard([&](){
+        if (s)
+            s->deleteLater();
+        drag->deleteLater();
+        m->deleteLater();
+    });
+
+    ASSERT_TRUE(DFileDragClient::checkMimeData(m));
+    {
+        QSignalSpy spy(s, &DFileDragServer::targetDataChanged);
+        DFileDragClient::setTargetData(m, "Key0", "Value0");
+        ASSERT_TRUE(QTest::qWaitFor([&spy](){
+            return spy.count() > 0;
+        }, 1000));
+        ASSERT_EQ(s->targetData("Key0"), QVariant("Value0"));
+    }
+    {
+        QUrl url = QUrl::fromLocalFile("/tmp/xxx");
+        QSignalSpy spy(drag, &DFileDrag::targetUrlChanged);
+        DFileDragClient::setTargetUrl(m, url);
+        ASSERT_TRUE(QTest::qWaitFor([&spy](){
+            return spy.count() > 0;
+        }, 1000));
+        ASSERT_EQ(drag->targetUrl(), url);
+    }
+
+    // client will delete on serverDestroyed
+    DFileDragClient *c = new DFileDragClient(m);
+    {
+        ASSERT_EQ(c->progress(), 0);
+        QSignalSpy spy(c, &DFileDragClient::progressChanged);
+        s->setProgress(30);
+        ASSERT_TRUE(QTest::qWaitFor([&spy](){
+            return spy.count() > 0;
+        }, 1000));
+        ASSERT_EQ(c->progress(), 30);
+    }
+    {
+        ASSERT_EQ(c->state(), 0);
+        QSignalSpy spy(c, &DFileDragClient::stateChanged);
+        s->setState(DFileDragState::Running);
+        ASSERT_TRUE(QTest::qWaitFor([&spy](){
+            return spy.count() > 0;
+        }, 1000));
+        ASSERT_EQ(c->state(), DFileDragState::Running);
+    }
+    {
+        QSignalSpy spy(c, &DFileDragClient::serverDestroyed);
+        s->deleteLater();
+        s = nullptr;
+        while(!spy.wait(10));
+        ASSERT_TRUE(spy.count() > 0);
+    }
+}


### PR DESCRIPTION
- emit serverDestroyed in ~DFileDragServer()
- DDndClientSignalRelay::serverDestroyed emit DFileDragClient::serverDestroyed
- add dfiledrag unit test