### PR TITLE
fix: Compiling error in qt6.4

### DIFF
--- a/include/util/dfontmanager.h
+++ b/include/util/dfontmanager.h
@@ -9,6 +9,7 @@
 #include <dtkgui_global.h>
 
 #include <QFont>
+#include <QObject>
 
 DGUI_BEGIN_NAMESPACE
 


### PR DESCRIPTION
  QThemeIconEntries changed from QList<QIconLoaderEngineEntry*>
to std::vector<std::unique_ptr<QIconLoaderEngineEntry>>
  QFont hasn't include QObject header file.