### PR TITLE
fix: 修复应用异常退出后颜色主题未保存的问题

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -376,6 +376,8 @@ void DGuiApplicationHelperPrivate::setPaletteType(DGuiApplicationHelper::ColorTy
 
     D_Q(DGuiApplicationHelper);
     Q_EMIT q->paletteTypeChanged(paletteType);
+
+    _d_dconfig->setValue(APP_THEME_TYPE, paletteType);
 }
 
 void DGuiApplicationHelperPrivate::initPaletteType() const
@@ -397,17 +399,11 @@ void DGuiApplicationHelperPrivate::initPaletteType() const
 
     applyThemeType(false);
 
-    auto conn = QObject::connect(_d_dconfig, &DConfig::valueChanged, _d_dconfig, [applyThemeType](const QString &key){
+    QObject::connect(_d_dconfig, &DConfig::valueChanged, _d_dconfig, [applyThemeType](const QString &key){
         if (key != APP_THEME_TYPE)
             return;
 
         applyThemeType(true);
-    });
-
-    QObject::connect(qGuiApp, &QGuiApplication::aboutToQuit, _d_dconfig, [conn](){
-        QObject::disconnect(conn);
-        int paletteType = DGuiApplicationHelper::instance()->paletteType();
-        _d_dconfig->setValue(APP_THEME_TYPE, paletteType);
     });
 }
 


### PR DESCRIPTION
修改为设置后立即保存

Log: 修复应用异常退出后颜色主题未保存的问题
Influence: 应用的主题选项在退出重启后未恢复上一次的选择
Bug: https://pms.uniontech.com/bug-view-201203.html
Change-Id: I73b92fd781737e757827bbb6aca87887c2c16ce9