### PR TITLE
fix: Wrong value of DPalette::TextLively

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -729,7 +729,7 @@ static QColor light_dpalette[DPalette::NColorTypes] {
     QColor(0, 0, 0, 0.85 * 255),    //TextTitle
     QColor(0, 0, 0, 0.6 * 255),     //TextTips
     QColor("#FF5736"),              //TextWarning
-    Qt::white,                      //TextLively
+    Qt::black,                      //TextLively
     QColor("#0081FF"),              //LightLively
     QColor("#0081FF"),              //DarkLively
     QColor(0, 0, 0, 0.05 * 255),    //FrameBorder


### PR DESCRIPTION
  TextLively is different between light and dark theme, otherwise
it can't see clearly in light theme.