### PR TITLE
chore: find qhelpgenerator from property

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libdevel
 Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends: debhelper-compat (= 12), pkg-config, 
- qtbase5-private-dev, qtbase5-dev-tools, doxygen, graphviz, qttools5-dev-tools,
+ qtbase5-private-dev, qtbase5-dev-tools, doxygen, graphviz, qttools5-dev,
  libdtkcore-dev, librsvg2-dev, libfreeimage-dev, libraw-dev, libgtest-dev, libgmock-dev,
  libqt5xdg-dev, libqt5xdgiconloader-dev, cmake, qt5-image-formats-plugins
 Standards-Version: 3.9.8
@@ -19,6 +19,7 @@ Description: Deepin Tool Kit Gui library
  This package contains the shared libraries.
 
 Package: libdtkgui5-bin
+Build-Profiles: <!nobin>
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
  libdtkgui5( =${binary:Version})
@@ -36,6 +37,7 @@ Description: Deepin Tool Kit Gui Devel library
  This package contains the header files and static libraries of DtkGui
 
 Package: libdtkgui-doc
+Build-Profiles: <!nodoc>
 Architecture: any
 Depends: ${misc:Depends}
 Description: Deepin Tool Kit Gui (Document)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -12,12 +12,23 @@ set (DOXYGEN_PROJECT_NUMBER ${CMAKE_PROJECT_VERSION} CACHE STRING "") # Should b
 set (DOXYGEN_EXTRACT_STATIC YES)
 set (DOXYGEN_OUTPUT_LANGUAGE "Chinese" CACHE STRING "Doxygen Output Language")
 set (DOXYGEN_IMAGE_PATH ${CMAKE_CURRENT_LIST_DIR}/images/)
-set (DOXYGEN_QHG_LOCATION "qhelpgenerator" CACHE STRING "Doxygen QHG path")
 set (DOXYGEN_QHP_NAMESPACE "org.deepin.dtk.gui")
 set (DOXYGEN_QCH_FILE "dtkgui.qch")
 set (DOXYGEN_QHP_VIRTUAL_FOLDER "dtkgui")
 set (DOXYGEN_HTML_EXTRA_STYLESHEET "" CACHE STRING "Doxygen custom stylesheet for HTML output")
 set (DOXYGEN_TAGFILES "qtcore.tags=qthelp://org.qt-project.qtcore/qtcore/" CACHE STRING "Doxygen tag files")
+
+# find from cmake target property
+if("${QT_VERSION_MAJOR}" STREQUAL "5")
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Help)
+else()
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ToolsTools)
+endif()
+get_target_property(_qhelpgenerator_location Qt${QT_VERSION_MAJOR}::qhelpgenerator IMPORTED_LOCATION)
+if("${_qhelpgenerator_location}" STREQUAL "")
+    set(_qhelpgenerator_location "qhelpgenerator")
+endif()
+set (DOXYGEN_QHG_LOCATION ${_qhelpgenerator_location} CACHE STRING "Doxygen QHG path")
 
 set (DOXYGEN_PREDEFINED
     "D_DECL_DEPRECATED_X(x)="


### PR DESCRIPTION
depends qttools5-dev or qt6-tools-dev
add Build-Profiles to ignore package build
(dpkg-buildpackage --build-profiles=nodoc)