### PR TITLE
fix: svg with filter attribute rendering exception

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -25,7 +25,6 @@ build() {
     cmake -GNinja \
     -DMKSPECS_INSTALL_DIR=lib/qt/mkspecs/modules/ \
     -DBUILD_DOCS=ON \
-    -DDTK_DISABLE_LIBRSVG=ON \
     -DQCH_INSTALL_DESTINATION=share/doc/qt \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX=/usr \

--- a/src/util/dsvgrenderer.cpp
+++ b/src/util/dsvgrenderer.cpp
@@ -145,7 +145,10 @@ QImage DSvgRendererPrivate::getImage(const QSize &size, const QString &elementId
     QImage image(size, QImage::Format_ARGB32_Premultiplied);
     image.fill(Qt::transparent);
     QPainter pa(&image);
-    qRenderer->render(&pa, elementId);
+    if (elementId.isEmpty())
+        qRenderer->render(&pa);
+    else
+        qRenderer->render(&pa, elementId);
     return image;
 #endif
 }

--- a/src/util/private/xdgiconproxyengine.cpp
+++ b/src/util/private/xdgiconproxyengine.cpp
@@ -49,6 +49,11 @@ static inline QPixmap entryPixmap(ScalableEntry *color_entry, const QSize &size,
     if (!color_entry)
         return QPixmap();
 
+    // init svgIcon with svg  absolute path
+    // force to use svg iconengine
+    if (color_entry->svgIcon.isNull())
+        color_entry->svgIcon = QIcon(color_entry->filename);
+
     if (auto d = color_entry->svgIcon.data_ptr())
         if (d->engine)
             return d->engine->pixmap(size, mode, state);
@@ -99,7 +104,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
 
     // 当size为1时表示此svg文件不需要处理ColorScheme标签
     if (!cache_color_scheme.isEmpty() && cache_color_scheme[DEEPIN_XDG_THEME::Text].size() == 1)
-        return color_entry->pixmap(size, mode, state);
+        return entryPixmap(color_entry, size, mode, state);
 
     const DEEPIN_XDG_THEME::PALETTE_MAP &color_scheme = DEEPIN_XDG_THEME::colorScheme.localData();
     QPixmap pm = color_scheme == cache_color_scheme ? entryPixmap(color_entry, size, mode, state) : QPixmap();
@@ -144,7 +149,7 @@ QPixmap XdgIconProxyEngine::followColorPixmap(ScalableEntry *color_entry, const 
         if (invalidBuffers) {
             // 此svg图标无ColorScheme标签时不应该再下面的操作，且应该记录下来，避免后续再处理svg文件内容
             entryToColorScheme[cache_key] = DEEPIN_XDG_THEME::PALETTE_MAP({ {DEEPIN_XDG_THEME::Text, "#"} });
-            return color_entry->pixmap(size, mode, state);
+            return entryPixmap(color_entry, size, mode, state);
         }
 
         // use the QSvgIconEngine


### PR DESCRIPTION
Svg filters attribute are not supported by QSvgRenderer, and it will not be. see https://bugreports.qt.io/browse/QTBUG-9081

XdgIconLoaderEngine(>3.6) use QSvgRenderer to render svg instead of svg icon engines https://github.com/lxqt/libqtxdg/blob/master/src/xdgiconloader/xdgiconloader.cpp#L814

Archlinux DTK_DISABLE_LIBRSVG=ON by default https://github.com/linuxdeepin/dtkgui/pull/130

- turn off DTK_DISABLE_LIBRSVG option
- force get pixmap from icon engines
- fix DSvgRenderer::toImage return null image with empty elementId on DTK_DISABLE_LIBRSVG