### PR TITLE
fix: Wrong IconName for DIconEngine

### DIFF
--- a/src/util/private/diconproxyengine.cpp
+++ b/src/util/private/diconproxyengine.cpp
@@ -172,7 +172,7 @@ QString DIconProxyEngine::iconName()
 const
 #endif
 {
-    return m_iconName;
+    return m_iconEngine ? m_iconEngine->iconName() : QString();
 }
 
 QString DIconProxyEngine::proxyKey()


### PR DESCRIPTION
  The icon names of `IconEngine` and `DIconProxyEngine` are
inconsistent when there is no such icon.

Issue: https://github.com/linuxdeepin/developer-center/issues/5760
