### PR TITLE
fix: indirect inclusion of QSharedPointer

### DIFF
--- a/include/util/ddciicon.h
+++ b/include/util/ddciicon.h
@@ -8,6 +8,7 @@
 #include <dtkgui_global.h>
 
 #include <QPixmap>
+#include <QSharedPointer>
 
 DCORE_BEGIN_NAMESPACE
 class DDciFile;


### PR DESCRIPTION
ddciicon.h does not explicitly include QSharedPointer, leading to
incomplete type. Include QSharedPointer explicitly.

Log: fix indirect inclusion of QSharedPointer
