### PR TITLE
feat: auto load qt translations

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -39,6 +39,7 @@
 #include <QLockFile>
 #include <QDirIterator>
 #include <QDesktopServices>
+#include <QTimer>
 
 #ifdef Q_OS_UNIX
 #include <QDBusError>
@@ -494,7 +495,10 @@ DGuiApplicationHelper::DGuiApplicationHelper()
     : QObject(nullptr)
     , DObject(*new DGuiApplicationHelperPrivate(this))
 {
-
+    // load qt/qtbase translation for qt app which load dtk ?
+    QTimer::singleShot(0, [](){
+        DGuiApplicationHelper::loadTranslator();
+    });
 }
 
 void DGuiApplicationHelper::initialize()


### PR DESCRIPTION
Normally, Qt applications need to explicitly load translations by themselves, including Qt translations. Here we take the initiative to help applications that have loaded dtk (including plugins) load translations.

Issue: https://github.com/linuxdeepin/developer-center/issues/6417