### PR TITLE
fix: debian build failed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,6 @@ Description: Deepin Tool Kit Gui library
  This package contains the shared libraries.
 
 Package: libdtkgui5-bin
-Build-Profiles: <!nobin>
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
  libdtkgui5( =${binary:Version})


### PR DESCRIPTION
invalid-profile-name-in-build-profiles-field nobin (in section for libdtkgui5-bin)