### PR TITLE
fix: font can't follow changes in qt6

### DIFF
--- a/src/private/dguiapplicationhelper_p.h
+++ b/src/private/dguiapplicationhelper_p.h
@@ -35,6 +35,7 @@ public:
     DGuiApplicationHelper::SizeMode fetchSizeMode(bool *isSystemSizeMode = nullptr) const;
     void notifyAppThemeChanged();
     void notifyAppThemeChangedByEvent();
+    void onApplicationPaletteChanged();
     // 返回程序是否自定义了调色板
     inline bool isCustomPalette() const;
     void setPaletteType(DGuiApplicationHelper::ColorType ct, bool emitSignal);


### PR DESCRIPTION
  `fontChanged` has been deprecated in qt6, and the signal can't
be emitted in `qdeepin` when font changed.
