### PR TITLE
fix: wrong availableSizes for DIconProxyEngine 

### DIFF
--- a/src/util/private/diconproxyengine.cpp
+++ b/src/util/private/diconproxyengine.cpp
@@ -176,6 +176,21 @@ const
     return m_iconEngine ? m_iconEngine->iconName() : QString();
 }
 
+QList<QSize> DIconProxyEngine::availableSizes(QIcon::Mode mode, QIcon::State state)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    const
+#endif
+{
+    return m_iconEngine ? m_iconEngine->availableSizes(mode, state) : QIconEngine::availableSizes(mode, state);
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool DIconProxyEngine::isNull()
+{
+    return m_iconEngine ? m_iconEngine->isNull() : QIconEngine::isNull();
+}
+#endif
+
 QString DIconProxyEngine::proxyKey()
 {
     ensureEngine();

--- a/src/util/private/diconproxyengine_p.h
+++ b/src/util/private/diconproxyengine_p.h
@@ -32,6 +32,16 @@ public:
 #else
     QString iconName() const override;
 #endif
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QList<QSize> availableSizes(QIcon::Mode mode = QIcon::Normal, QIcon::State state = QIcon::Off) override;
+#else
+    QList<QSize> availableSizes(QIcon::Mode mode = QIcon::Normal, QIcon::State state = QIcon::Off) const override;
+#endif
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool isNull() override;
+#endif
     inline QString themeName() const { return m_iconThemeName; }
 
     QString proxyKey();


### PR DESCRIPTION
  We should call proxy's `availableSizes` function.
  `availableSizes` always return empty list for icons, it causes
`QPainter::begin: Paint device returned engine == 0` when painting
to QImage.
