### PR TITLE
fix: PlaceholderText color tweak

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -855,9 +855,7 @@ DPalette DGuiApplicationHelper::standardPalette(DGuiApplicationHelper::ColorType
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
         if (role == QPalette::PlaceholderText) {
-            // 5.15新添加此颜色 这里使用5.11的颜色保证效果与5.11对齐
             color = dcolor_list[DPalette::PlaceholderText];
-            continue;
         }
 #endif
         // 处理半透明色


### PR DESCRIPTION
原来 continue 只是不用 QColor()/黑色 覆盖
去掉 continue 才是使用 DPalette 中的 PlaceholderText 覆盖..

Issue: https://github.com/linuxdeepin/developer-center/issues/7554