### PR TITLE
fix: missing initialization for baseFont of fontManager

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -1336,6 +1336,8 @@ const DFontManager *DGuiApplicationHelper::fontManager() const
 {
     // 为对象初始化信号链接
     if (!_globalFM.exists()) {
+        // fontManager's base font is update from qGuiApp.
+        _globalFM->setBaseFont(qGuiApp->font());
         connect(this, &DGuiApplicationHelper::fontChanged, _globalFM, &DFontManager::setBaseFont);
     }
 


### PR DESCRIPTION
We should update baseFont from qGuiApp not just when font changed.

Issue: https://github.com/linuxdeepin/developer-center/issues/8040
