### PR TITLE
fix: jagged edges on ddciicon

### DIFF
--- a/src/util/ddciicon.cpp
+++ b/src/util/ddciicon.cpp
@@ -729,7 +729,8 @@ void DDciIconPrivate::paint(QPainter *painter, const QRectF &rect, Qt::Alignment
         if (rect.width() < targetRect.width())
             targetRect = rect;
 
-        painter->drawImage(targetRect, layer);
+        auto scaleImage = layer.scaled(targetRect.size().toSize(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        painter->drawImage(targetRect, scaleImage);
     }
 }
 


### PR DESCRIPTION
Use smooth scaling before drawing to smaller QImage

Issue: https://github.com/linuxdeepin/developer-center/issues/8691