### PR TITLE
fix: availableSizes not work on Qt6

### DIFF
--- a/src/util/private/dbuiltiniconengine.cpp
+++ b/src/util/private/dbuiltiniconengine.cpp
@@ -291,6 +291,26 @@ QString DBuiltinIconEngine::iconName()
     return m_iconName;
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+QList<QSize> DBuiltinIconEngine::availableSizes(QIcon::Mode mode, QIcon::State state)
+{
+    ensureLoaded();
+
+    QList<QSize> sizes;
+    const int N = m_info.entries.size();
+    sizes.reserve(N);
+
+    // Gets all sizes from the DirectoryInfo entries
+    for (int i = 0; i < N; ++i) {
+        const auto& entry = m_info.entries.at(i);
+        int size = entry->dir.size;
+        sizes.append(QSize(size, size));
+    }
+
+    return sizes;
+}
+#endif
+
 QThemeIconInfo DBuiltinIconEngine::loadIcon(const QString &iconName, uint key)
 {
     QThemeIconInfo info;

--- a/src/util/private/dbuiltiniconengine_p.h
+++ b/src/util/private/dbuiltiniconengine_p.h
@@ -33,6 +33,7 @@ public:
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QString iconName() override;
+    QList<QSize> availableSizes(QIcon::Mode mode = QIcon::Normal, QIcon::State state = QIcon::Off) override;
 #else
     QString iconName() const override;
 #endif

--- a/src/util/private/dciiconengine.cpp
+++ b/src/util/private/dciiconengine.cpp
@@ -158,6 +158,22 @@ const
     return m_iconName;
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+QList<QSize> DDciIconEngine::availableSizes(QIcon::Mode mode, QIcon::State state)
+{
+    ensureIconTheme();
+
+    const auto availableSizes = m_dciIcon.availableSizes(dciTheme(), DDciIcon::Normal);
+    QList<QSize> sizes;
+    sizes.reserve(availableSizes.size());
+
+    for (int size : availableSizes)
+        sizes.append(QSize(size, size));
+
+    return sizes;
+}
+#endif
+
 void DDciIconEngine::virtual_hook(int id, void *data)
 {
     ensureIconTheme();

--- a/src/util/private/dciiconengine_p.h
+++ b/src/util/private/dciiconengine_p.h
@@ -30,6 +30,7 @@ public:
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QString iconName() override;
+    QList<QSize> availableSizes(QIcon::Mode mode = QIcon::Normal, QIcon::State state = QIcon::Off) override;
 #else
     QString iconName() const override;
 #endif


### PR DESCRIPTION
Qt6 QIconEngine::availableSizes will not call
virtual_hook(QIconEngine::AvailableSizesHook