### PR TITLE
fix: Print "load translate" debug log to channels

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -1638,7 +1638,7 @@ bool DGuiApplicationHelper::loadTranslator(const QString &fileName, const QList<
                 DPathBuf path(dir);
                 QString translatePath = (path / translateFilename).toString();
                 if (QFile::exists(translatePath + ".qm")) {
-                    qDebug() << "load translate" << translatePath;
+                    qCDebug(dgAppHelper) << "load translate" << translatePath;
                     auto translator = new QTranslator(qApp);
                     translator->load(translatePath);
                     qApp->installTranslator(translator);


### PR DESCRIPTION
Avoid printing such logs to terminal

Bug: https://pms.uniontech.com/bug-view-284539.html
Log: Print "load translate" debug log to channels