### PR TITLE
feat: support treeland platform for wmHelper

### DIFF
--- a/src/kernel/dwindowmanagerhelper.cpp
+++ b/src/kernel/dwindowmanagerhelper.cpp
@@ -24,6 +24,10 @@
 
 #include <functional>
 
+#ifndef DTK_DISABLE_TREELAND
+#include "plugins/platform/treeland/dtreelandwindowmanagerhelper.h"
+#endif
+
 DGUI_BEGIN_NAMESPACE
 
 #define DEFINE_CONST_CHAR(Name) const char _##Name[] = "_d_" #Name
@@ -110,6 +114,11 @@ public:
 
     mutable QList<DForeignWindow *> windowList;
 };
+
+// TODO abstract an interface to adapt to various WM.
+#ifndef DTK_DISABLE_TREELAND
+Q_GLOBAL_STATIC(TreelandWindowManagerHelper, treelandWMHGlobal)
+#endif
 
 class DWindowManagerHelper_ : public DWindowManagerHelper {};
 Q_GLOBAL_STATIC(DWindowManagerHelper_, wmhGlobal)
@@ -323,6 +332,11 @@ DWindowManagerHelper::~DWindowManagerHelper()
  */
 DWindowManagerHelper *DWindowManagerHelper::instance()
 {
+#ifndef DTK_DISABLE_TREELAND
+    if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
+        return treelandWMHGlobal;
+    }
+#endif
     return wmhGlobal;
 }
 
@@ -519,6 +533,11 @@ void DWindowManagerHelper::popupSystemWindowMenu(const QWindow *window)
  */
 bool DWindowManagerHelper::hasBlurWindow() const
 {
+#ifndef DTK_DISABLE_TREELAND
+    if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
+        return treelandWMHGlobal->hasBlurWindow();
+    }
+#endif
     return callPlatformFunction<bool, bool(*)()>(_hasBlurWindow);
 }
 
@@ -528,6 +547,12 @@ bool DWindowManagerHelper::hasBlurWindow() const
  */
 bool DWindowManagerHelper::hasComposite() const
 {
+#ifndef DTK_DISABLE_TREELAND
+    if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
+        return treelandWMHGlobal->hasComposite();
+    }
+#endif
+
     QFunctionPointer hasComposite = Q_NULLPTR;
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
@@ -557,6 +582,11 @@ bool DWindowManagerHelper::hasComposite() const
  */
 bool DWindowManagerHelper::hasNoTitlebar() const
 {
+#ifndef DTK_DISABLE_TREELAND
+    if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
+        return treelandWMHGlobal->hasNoTitlebar();
+    }
+#endif
     return callPlatformFunction<bool, bool(*)()>(_hasNoTitlebar);
 }
 

--- a/src/plugins/platform/treeland/dtreelandwindowmanagerhelper.cpp
+++ b/src/plugins/platform/treeland/dtreelandwindowmanagerhelper.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dtreelandwindowmanagerhelper.h"
+#include "personalizationwaylandclientextension.h"
+
+DGUI_BEGIN_NAMESPACE
+
+TreelandWindowManagerHelper::TreelandWindowManagerHelper(QObject *parent)
+    : DWindowManagerHelper(parent)
+{
+    connect(PersonalizationManager::instance(), &PersonalizationManager::activeChanged, this, [this](){
+        Q_EMIT hasBlurWindowChanged();
+        Q_EMIT hasNoTitlebarChanged();
+    });
+}
+
+bool TreelandWindowManagerHelper::hasBlurWindow() const
+{
+    return PersonalizationManager::instance()->isSupported();
+}
+
+bool TreelandWindowManagerHelper::hasComposite() const
+{
+    return true;
+}
+
+bool TreelandWindowManagerHelper::hasNoTitlebar() const
+{
+    return PersonalizationManager::instance()->isSupported();
+}
+
+DGUI_END_NAMESPACE

--- a/src/plugins/platform/treeland/dtreelandwindowmanagerhelper.h
+++ b/src/plugins/platform/treeland/dtreelandwindowmanagerhelper.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef DTREELANDWINDOWMANAGERHELPER_H
+#define DTREELANDWINDOWMANAGERHELPER_H
+
+#include "dtkgui_global.h"
+#include "dwindowmanagerhelper.h"
+#include <QObject>
+
+DGUI_BEGIN_NAMESPACE
+
+class TreelandWindowManagerHelper : public DWindowManagerHelper
+{
+public:
+    explicit TreelandWindowManagerHelper(QObject *parent = 0);
+    bool hasBlurWindow() const;
+    bool hasComposite() const;
+    bool hasNoTitlebar() const;
+};
+
+DGUI_END_NAMESPACE
+
+#endif // DTREELANDWINDOWMANAGERHELPER_H


### PR DESCRIPTION
WindowManager's some interface may be deprecated, like MotifFunctions
and allWindowIdList.
and there is currently no abstraction of platform common
interfaces.

pms: BUG-287901
