### PR TITLE
fix: app crashed when window destroyed in quick

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
@@ -53,10 +53,6 @@ MoveWindowHelper::MoveWindowHelper(QWindow *window)
 
 MoveWindowHelper::~MoveWindowHelper()
 {
-    if (DVtableHook::hasVtable(m_window)) {
-        DVtableHook::resetVtable(m_window);
-    }
-
     mapped.remove(qobject_cast<QWindow*>(parent()));
 }
 


### PR DESCRIPTION
ghostVtable will be released whenever Window is destroyed by
delete or deleteLater function, we don't need to resetVtable,
and we shouldn't resetVtable when destructing m_window.

pms: BUG-368399
