### PR TITLE
fix: accessing wild pointer in qt6

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
@@ -51,7 +51,7 @@ MoveWindowHelper::MoveWindowHelper(QWindow *window)
 
 MoveWindowHelper::~MoveWindowHelper()
 {
-    mapped.remove(qobject_cast<QWindow*>(parent()));
+    mapped.remove(static_cast<QWindow*>(parent()));
 }
 
 void MoveWindowHelper::updateEnableSystemMoveFromProperty()
@@ -178,7 +178,8 @@ DTreeLandPlatformWindowHelper::DTreeLandPlatformWindowHelper(QWindow *window)
 
 DTreeLandPlatformWindowHelper::~DTreeLandPlatformWindowHelper()
 {
-    windowMap.remove(window());
+    // see tst_qwindow.cpp tst_QWindow::qobject_castOnDestruction()
+    windowMap.remove(static_cast<QWindow*>(parent()));
 }
 
 bool DTreeLandPlatformWindowHelper::eventFilter(QObject *watched, QEvent *event) {


### PR DESCRIPTION
qobject_cast<QWindow*>(window) is returned nullptr if window is destroyed in qt6, and we can see it  on tst_QWindow::qobject_castOnDestruction() in tst_qwindow.cpp.
Object's address may be the same as before  in qt6,  memory may be optimized.

pms: BUG-299239
