### PR TITLE
chore: correct typos about Dtk::Gui::DDciIcon::IconAttribute

### DIFF
--- a/docs/util/ddciicon.zh_CN.dox
+++ b/docs/util/ddciicon.zh_CN.dox
@@ -223,7 +223,7 @@ cmake --build build
     | Light | 0 |
     | Dark  | 1 |
 
-@enum Dtk::Gui::DDciIcon::IconAttibute
+@enum Dtk::Gui::DDciIcon::IconAttribute
 @brief DCI图标属性
 @details
     | 键     | 值 |
@@ -282,7 +282,7 @@ cmake --build build
 @param[in] theme 图标主题
 @param[in] mode 图标模式，默认为Normal
 
-@fn bool Dtk::Gui::DDciIcon::isSupportedAttribute(DDciIconMatchResult result, IconAttibute attr)
+@fn bool Dtk::Gui::DDciIcon::isSupportedAttribute(DDciIconMatchResult result, IconAttribute attr)
 @brief 判断DCI图标是否支持指定属性
 @param[in] result DCI图标匹配结果
 @param[in] attr 图标属性

--- a/include/util/ddciicon.h
+++ b/include/util/ddciicon.h
@@ -77,9 +77,10 @@ public:
         Light = 0,
         Dark = 1
     };
-    enum IconAttibute {
+    D_DECL_DEPRECATED enum IconAttibute {
         HasPalette = 0x001
     };
+    using IconAttribute = DDciIcon::IconAttibute;
     enum IconMatchedFlag {
         None = 0,
         DontFallbackMode = 0x01,
@@ -106,8 +107,8 @@ public:
     int actualSize(int size, Theme theme, Mode mode = Normal) const;
 
     QList<int> availableSizes(Theme theme, Mode mode = Normal) const;
-    bool isSupportedAttribute(DDciIconMatchResult result, IconAttibute attr) const;
-    static bool isSupportedAttribute(const DDciIconImage &image, IconAttibute attr);
+    bool isSupportedAttribute(DDciIconMatchResult result, IconAttribute attr) const;
+    static bool isSupportedAttribute(const DDciIconImage &image, IconAttribute attr);
 
     QPixmap pixmap(qreal devicePixelRatio, int iconSize, Theme theme, Mode mode = Normal,
                    const DDciIconPalette &palette = DDciIconPalette()) const;

--- a/src/util/ddciicon.cpp
+++ b/src/util/ddciicon.cpp
@@ -852,7 +852,7 @@ QList<int> DDciIcon::availableSizes(DDciIcon::Theme theme, DDciIcon::Mode mode) 
     return sizes;
 }
 
-bool DDciIcon::isSupportedAttribute(DDciIconMatchResult result, IconAttibute attr) const
+bool DDciIcon::isSupportedAttribute(DDciIconMatchResult result, IconAttribute attr) const
 {
     switch (attr) {
     case HasPalette:
@@ -864,7 +864,7 @@ bool DDciIcon::isSupportedAttribute(DDciIconMatchResult result, IconAttibute att
     return false;
 }
 
-bool DDciIcon::isSupportedAttribute(const DDciIconImage &image, IconAttibute attr)
+bool DDciIcon::isSupportedAttribute(const DDciIconImage &image, IconAttribute attr)
 {
     if (image.isNull())
         return false;


### PR DESCRIPTION
Renaming enum would break ABI, but using doesn't modify ABI.

pms: BUG-368399