### PR TITLE
fix: build failed in qt5

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -119,8 +119,8 @@ Q_GLOBAL_STATIC(DFontManager, _globalFM)
 #define WINDOW_THEME_KEY "_d_platform_theme"
 
 #define DTK_ANIMATIONS_ENV "D_DTK_DISABLE_ANIMATIONS"
-Q_GLOBAL_STATIC(OrgDeepinDTKPreference, _d_dconfig, DTK_CORE_NAMESPACE::DConfig::globalThread(), nullptr,
-                "org.deepin.dtk.preference", DTK_CORE_NAMESPACE::DSGApplication::id(), {}, false, nullptr)
+Q_GLOBAL_STATIC_WITH_ARGS(OrgDeepinDTKPreference, _d_dconfig, (DTK_CORE_NAMESPACE::DConfig::globalThread(), nullptr,
+                                                               "org.deepin.dtk.preference", DTK_CORE_NAMESPACE::DSGApplication::id(), {}, false, nullptr))
 
 /*!
  @private


### PR DESCRIPTION
Changed Q_GLOBAL_STATIC to Q_GLOBAL_STATIC_WITH_ARGS for
OrgDeepinDTKPreference initialization
This modification provides better type safety and clearer syntax for the
complex initialization parameters
The change maintains the same functionality while following Qt's
recommended practices for static initialization

refactor: 更新 DConfig 初始化语法

将 Q_GLOBAL_STATIC 改为 Q_GLOBAL_STATIC_WITH_ARGS 用于
OrgDeepinDTKPreference 初始化
此修改为复杂的初始化参数提供了更好的类型安全性和更清晰的语法
该变更保持了相同的功能，同时遵循 Qt 推荐的静态初始化实践
