### PR TITLE
chore: bump version to 5.7.16

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtkgui (5.7.16) unstable; urgency=medium
+
+  * Release 5.7.16
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Mon, 19 May 2025 17:21:59 +0800
+
 dtkgui (5.7.15) unstable; urgency=medium
 
   * fix: correct bitwise operation in preference handling


### PR DESCRIPTION
update changelog to 5.7.16