### PR TITLE
chore: use another QTranslator::load overload to tidy code

### DIFF
--- a/include/kernel/dguiapplicationhelper.h
+++ b/include/kernel/dguiapplicationhelper.h
@@ -124,6 +124,7 @@ public:
     static QStringList userManualPaths(const QString &appName);
     bool hasUserManual() const;
 
+    static bool loadTranslator(const QString &fileName, const QString &appName, const QList<QLocale> &localeFallback = QList<QLocale>() << QLocale::system());
     static bool loadTranslator(const QString &fileName, const QList<QString> &translateDirs, const QList<QLocale> &localeFallback);
     static bool loadTranslator(const QList<QLocale> &localeFallback = QList<QLocale>() << QLocale::system());
 

--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -1632,6 +1632,28 @@ bool DGuiApplicationHelper::hasUserManual() const
     return userManualPaths(qApp->applicationName()).size() > 0;
 }
 
+static inline QStringList translateDirs(const QString &appName)
+{
+    Q_ASSERT(!appName.isEmpty());
+
+    QStringList dirs;
+
+    DCORE_USE_NAMESPACE
+    //("/home/user/.local/share", "/usr/local/share", "/usr/share")
+    auto dataDirs = DStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
+    for (const auto &path : dataDirs) {
+        DPathBuf pathBuf(path);
+        dirs << (pathBuf / appName / "translations").toString();
+    }
+
+    return dirs;
+}
+
+bool DGuiApplicationHelper::loadTranslator(const QString &fileName, const QString &appName, const QList<QLocale> &localeFallback)
+{
+    return loadTranslator(fileName, translateDirs(appName), localeFallback);
+}
+
 bool DGuiApplicationHelper::loadTranslator(const QString &fileName, const QList<QString> &translateDirs, const QList<QLocale> &localeFallback)
 {
     DCORE_USE_NAMESPACE;
@@ -1644,40 +1666,30 @@ bool DGuiApplicationHelper::loadTranslator(const QString &fileName, const QList<
     for (auto item : defaultDirPrefix)
         dirs << item.join("translations").toString();
 
-    QStringList missingQmfiles;
     for (const auto &locale : localeFallback) {
-        QStringList translateFilenames {QString("%1_%2").arg(fileName).arg(locale.name())};
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-        auto behavior = Qt::SkipEmptyParts;
-#else
-        auto behavior = QString::SkipEmptyParts;
-#endif
-        const QStringList parseLocalNameList = locale.name().split("_", behavior);
-        if (parseLocalNameList.length() > 0)
-            translateFilenames << QString("%1_%2").arg(fileName).arg(parseLocalNameList.at(0));
-
-        for (const auto &translateFilename : translateFilenames) {
-            for (const auto &dir : dirs) {
-                DPathBuf path(dir);
-                QString translatePath = (path / translateFilename).toString();
-                if (QFile::exists(translatePath + ".qm")) {
-                    qCDebug(dgAppHelper) << "load translate" << translatePath;
-                    auto translator = new QTranslator(qApp);
-                    translator->load(translatePath);
-                    qApp->installTranslator(translator);
-                    qApp->setProperty("dapp_locale", locale.name());
-                    return true;
-                }
+        for (const auto &dir : dirs) {
+            auto translator = new QTranslator(qApp);
+            // QTranslator::load(locale, filename, prefix, directory, suffix) automatically handles
+            // locale fallback (e.g., zh_CN -> zh -> C) and file existence checking
+            if (translator->load(locale, fileName, QString(), dir)) {
+                qCDebug(dgAppHelper) << "load translate" << fileName << "for locale" << locale.name() << "from" << dir;
+                qApp->installTranslator(translator);
+                qApp->setProperty("dapp_locale", locale.name());
+                return true;
             }
-
-            // fix english does not need to translation.
-            if (locale.language() != QLocale::English)
-                missingQmfiles << translateFilename + ".qm";
+            delete translator; // Clean up if loading failed
         }
     }
 
-    if (missingQmfiles.size() > 0) {
-        qWarning() << fileName << "can not find qm files" << missingQmfiles;
+    // Collect locale names for warning message
+    QStringList localeNames;
+    for (const auto &locale : localeFallback) {
+        if (locale.language() != QLocale::English) // English does not need translation
+            localeNames << locale.name();
+    }
+    
+    if (!localeNames.isEmpty()) {
+        qWarning() << fileName << "can not find qm files for locales" << localeNames;
     }
     return false;
 }
@@ -1692,25 +1704,15 @@ bool DGuiApplicationHelper::loadTranslator(const QList<QLocale> &localeFallback)
 
     DCORE_USE_NAMESPACE
     //("/home/user/.local/share", "/usr/local/share", "/usr/share")
-    auto dataDirs = DStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
-    QList<QString> qtranslateDirs = { qTranslationsPath };
-    for (const auto &path : dataDirs) {
-        DPathBuf pathBuf(path);
-        qtranslateDirs << (pathBuf / "qt" QT_STRINGIFY(QT_VERSION_MAJOR) / "translations").toString();
-    }
+    auto qtranslateDirs = translateDirs("qt" QT_STRINGIFY(QT_VERSION_MAJOR));
+    qtranslateDirs.prepend(qTranslationsPath);
 
     loadTranslator("qt", qtranslateDirs, localeFallback);
     loadTranslator("qtbase", qtranslateDirs, localeFallback);
 
-    QList<QString> translateDirs;
     auto appName = qApp->applicationName();
-    for (const auto &path : dataDirs) {
-        DPathBuf pathBuf(path);
-        translateDirs << (pathBuf / appName / "translations").toString();
-    }
 
-    // ${translateDir}/${appName}_${localeName}.qm
-    return loadTranslator(appName, translateDirs, localeFallback);
+    return loadTranslator(appName, appName, localeFallback);
 }
 
 DGuiApplicationHelper::SizeMode DGuiApplicationHelper::sizeMode() const


### PR DESCRIPTION
使用另一个 `QTranslator::load()` 重载来使代码更简洁,并潜在的支持 `QLocale::uiLanguages()`.
