### PR TITLE
fix: make version parameter optional in release workflow

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string

--- a/rpm/dtkgui.spec
+++ b/rpm/dtkgui.spec
@@ -1,6 +1,6 @@
 Name:           dtkgui
-Version: 5.7.17
-Release: 1
+Version:        5.7.17
+Release:        1%{?dist}
 Summary:        Deepin dtkgui
 License:        LGPLv3+
 URL:            https://github.com/linuxdeepin/dtkgui


### PR DESCRIPTION
1. Changed version parameter from required to optional in GitHub
workflow
2. Fixed spec file formatting by aligning Version and Release fields
3. Added %{?dist} macro to Release field for proper RPM building

The changes make the release workflow more flexible by allowing version-
less releases while maintaining proper RPM spec file formatting and
distribution tagging. This helps with automated release processes and
ensures consistent package building across different distributions.

fix: 在发布工作流中使版本参数可选

1. 将 GitHub 工作流中的版本参数从必填改为可选
2. 修复 spec 文件格式，对齐 Version 和 Release 字段
3. 在 Release 字段添加 %{?dist} 宏以支持正确的 RPM 构建

这些变更使发布工作流更加灵活，允许无版本号的发布，同时保持 RPM spec 文件
的正确格式和分发标签。这有助于自动化发布流程并确保在不同发行版上一致的软
件包构建。
