### PR TITLE
docs: update REUSE license file for CHANGELOG

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -34,7 +34,7 @@ Copyright: None
 License: LGPL-3.0-or-later
 
 # README
-Files: *README.md *README.zh_CN.md
+Files: *README.md *README.zh_CN.md CHANGELOG.md
 Copyright: None
 License:  CC-BY-4.0
 


### PR DESCRIPTION
Added CHANGELOG.md to the list of files under CC-BY-4.0 license
in .reuse/dep5
This change ensures proper licensing attribution for the changelog file
The modification follows the project's REUSE compliance standards

docs: 更新 REUSE 许可文件以包含 CHANGELOG

在 .reuse/dep5 文件中将 CHANGELOG.md 添加到 CC-BY-4.0 许可证下的文件列表
此变更确保了对变更日志文件的正确许可归属
修改遵循项目的 REUSE 合规标准
