### PR TITLE
feat: add concurrent processing for DCI icon conversion

### DIFF
--- a/tools/dci-icon-theme/CMakeLists.txt
+++ b/tools/dci-icon-theme/CMakeLists.txt
@@ -1,12 +1,15 @@
 set(BIN_NAME dci-icon-theme)
 set(TARGET_NAME ${BIN_NAME}${DTK_VERSION_MAJOR})
 
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Concurrent REQUIRED)
+
 add_executable(${TARGET_NAME}
     main.cpp
 )
 
 target_link_libraries(${TARGET_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Concurrent
     ${LIB_NAME}
 )
 set_target_properties(${TARGET_NAME} PROPERTIES OUTPUT_NAME ${BIN_NAME})


### PR DESCRIPTION
1. Added QtConcurrent support for parallel processing of icon files
2. Implemented error handling with custom DciProcessingError exception
3. Grouped icon files by name to avoid concurrent access to same DCI
file
4. Improved performance by processing icon groups in parallel
5. Added proper error propagation and atomic flag for early termination
6. Maintained existing functionality while adding concurrency
7. Each icon group is processed as a unit to ensure thread safety with
DCI files

feat: 为DCI图标转换添加并发处理

1. 添加QtConcurrent支持以实现图标文件的并行处理
2. 使用自定义DciProcessingError异常实现错误处理
3. 按名称分组图标文件以避免对同一DCI文件的并发访问
4. 通过并行处理图标组提高性能
5. 添加适当的错误传播和原子标志用于提前终止
6. 在添加并发性的同时保持现有功能
7. 每个图标组作为一个单元处理以确保DCI文件的线程安全
