### PR TITLE
feat: switch to QGuiApplication for SVG rendering

### DIFF
--- a/tools/dci-icon-theme/CMakeLists.txt
+++ b/tools/dci-icon-theme/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(${TARGET_NAME}
 )
 
 target_link_libraries(${TARGET_NAME} PRIVATE
-    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Concurrent
     ${LIB_NAME}
 )

--- a/tools/dci-icon-theme/main.cpp
+++ b/tools/dci-icon-theme/main.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include <QCoreApplication>
+#include <QGuiApplication>
 #include <QImageReader>
 #include <QCommandLineParser>
 #include <QDirIterator>
@@ -240,7 +240,7 @@ int main(int argc, char *argv[])
                                                 "and -1 to use the image handler default settings.\n"
                                                 "The higher the quality, the larger the dci icon file size", "scale quality");
 
-    QCoreApplication a(argc, argv);
+    QGuiApplication a(argc, argv);
 
     a.setApplicationName("dci-icon-theme");
     a.setApplicationVersion(QString("%1.%2.%3")


### PR DESCRIPTION
1. Changed from QCoreApplication to QGuiApplication to support SVG rendering
2. Updated CMakeLists to link against QtGui instead of QtCore
3. This change is necessary because SVG rendering requires GUI components
4. Note: CLI environment users must set QT_QPA_PLATFORM=offscreen

feat: 切换到 QGuiApplication 以支持 SVG 渲染

1. 从 QCoreApplication 切换到 QGuiApplication 以支持 SVG 渲染
2. 更新 CMakeLists 链接 QtGui 替代 QtCore
3. 此变更是必要的因为 SVG 渲染需要 GUI 组件
4. 注意：命令行环境用户需要设置 QT_QPA_PLATFORM=offscreen