### PR TITLE
feat: add flags parameter to DDciIconPlayer play method

### DIFF
--- a/docs/util/ddciiconplayer.zh_CN.dox
+++ b/docs/util/ddciiconplayer.zh_CN.dox
@@ -171,6 +171,11 @@
 @details 为指定的图标模式计算要显示的内容，这可能会导致 currentImage 发生变化。这是个一次性行为，不会影响下一次调用 setMode 后的结果。
 @param[in] mode 指定要播放的图标模式，如果此模式支持动画，会触发此模式自身的动画播放（与 setMode 导致的动画不同的是，此动画不涉及两种模式变化时的过渡规则），否则将修改 currentImage 为此模式对应的静态图片资源。
 
+@fn Dtk::Gui::DDciIconPlayer::play(DDciIcon::Mode mode, DDciIconImagePlayer::Flags flags)
+@details 为指定的图标模式和播放参数计算要显示的内容。
+@param[in] mode 指定要播放的图标模式。
+@param[in] flags 播放参数
+
 @fn Dtk::Gui::DDciIconPlayer::stop()
 @details 如果当前正在播放动画，则停止当前动画的播放，但不会影响队列中下一个动画的播放。可能会导致 DDciIconPlayer::state 发生变化。
 @sa DDciIconPlayer::abort

--- a/include/util/ddciiconplayer.h
+++ b/include/util/ddciiconplayer.h
@@ -106,6 +106,7 @@ public:
 
     QImage currentImage() const;
     void play(DDciIcon::Mode mode);
+    void play(DDciIcon::Mode mode, DDciIconImagePlayer::Flags flags);
     void stop();
     void abort();
 

--- a/src/util/ddciiconplayer.cpp
+++ b/src/util/ddciiconplayer.cpp
@@ -1075,10 +1075,15 @@ QImage DDciIconPlayer::currentImage() const
     return d->image;
 }
 
-void DDciIconPlayer::play(DDciIcon::Mode mode)
+void DDciIconPlayer::play(DDciIcon::Mode mode, DDciIconImagePlayer::Flags flags)
 {
     D_D(DDciIconPlayer);
-    d->play(mode, DDciIconImagePlayer::IgnoreLastImageLoop);
+    d->play(mode, flags);
+}
+
+void DDciIconPlayer::play(DDciIcon::Mode mode)
+{
+    play(mode, DDciIconImagePlayer::IgnoreLastImageLoop);
 }
 
 void DDciIconPlayer::stop()


### PR DESCRIPTION
1. Added new overloaded play method that accepts
DDciIconImagePlayer::Flags parameter
2. Modified existing play method to call new method with default
IgnoreLastImageLoop flag
3. Updated documentation to reflect new method signature and behavior
4. Allows more control over icon playback behavior through flags
parameter

feat: 为 DDciIconPlayer 的 play 方法添加 flags 参数

1. 添加了新的重载 play 方法，接受 DDciIconImagePlayer::Flags 参数
2. 修改现有 play 方法以使用默认的 IgnoreLastImageLoop 标志调用新方法
3. 更新文档以反映新的方法签名和行为
4. 通过 flags 参数提供对图标播放行为的更多控制
