### PR TITLE
feat: add T11 font size and adjust T5 default

### DIFF
--- a/include/util/dfontmanager.h
+++ b/include/util/dfontmanager.h
@@ -44,6 +44,7 @@ public:
         T8,
         T9,
         T10,
+        T11,
         NSizeTypes
     };
     Q_ENUM(SizeType)
@@ -109,6 +110,10 @@ public:
     inline const QFont t10() const
     {
         return get(T10);
+    }
+    inline const QFont t11() const
+    {
+        return get(T11);
     }
 
 Q_SIGNALS:

--- a/src/private/dfontmanager_p.h
+++ b/src/private/dfontmanager_p.h
@@ -17,7 +17,7 @@ class DFontManagerPrivate : public DTK_CORE_NAMESPACE::DObjectPrivate
 public:
     DFontManagerPrivate(DFontManager *qq);
 
-    int fontPixelSize[DFontManager::NSizeTypes] = {40, 30, 24, 20, 17, 14, 13, 12, 11, 10};
+    int fontPixelSize[DFontManager::NSizeTypes] = {40, 30, 24, 20, 16, 14, 13, 12, 11, 10, 8};
     int baseFontSizeType = DFontManager::T6;
     // 字号的差值
     int fontPixelSizeDiff = 0;

--- a/src/util/dfontmanager.cpp
+++ b/src/util/dfontmanager.cpp
@@ -49,7 +49,7 @@ DFontManager::~DFontManager()
   \value T4
   系统级别为 T4 的字体大小, 默认是20 px
   \value T5
-  系统级别为 T5 的字体大小, 默认是17 px
+  系统级别为 T5 的字体大小, 默认是16 px
   \value T6
   系统级别为 T6 的字体大小, 默认是14 px
   \value T7
@@ -60,6 +60,8 @@ DFontManager::~DFontManager()
   系统级别为 T9 的字体大小, 默认是11 px
   \value T10
   系统级别为 T10 的字体大小, 默认是10 px
+  \value T11
+  系统级别为 T11 的字体大小, 默认是8 px
 
   \omitvalue NSizeTypes
  */

--- a/tests/src/ut_dfontmanager.cpp
+++ b/tests/src/ut_dfontmanager.cpp
@@ -76,4 +76,5 @@ TEST_F(TDFontManager, testFontSize)
     ASSERT_EQ(manager->t8().pixelSize(), manager->fontPixelSize(DFontManager::T8));
     ASSERT_EQ(manager->t9().pixelSize(), manager->fontPixelSize(DFontManager::T9));
     ASSERT_EQ(manager->t10().pixelSize(), manager->fontPixelSize(DFontManager::T10));
+    ASSERT_EQ(manager->t11().pixelSize(), manager->fontPixelSize(DFontManager::T11));
 }


### PR DESCRIPTION
Added T11 font size with 8px default value to extend the font size options
Modified T5 default size from 17px to 16px for better size progression Updated font pixel size array to include the new T11 size Added t11() accessor method and corresponding test case cherry-pick from: https://github.com/linuxdeepin/dtkwidget/commit/2c3b351b439f56a9373538e8c6b6660167eb378d

feat: 添加 T11 字体大小并调整 T5 默认值

添加了默认值为 8px 的 T11 字体大小以扩展字体大小选项
将 T5 默认大小从 17px 修改为 16px 以获得更好的大小递进
更新了字体像素大小数组以包含新的 T11 大小
添加了 t11() 访问器方法和相应的测试用例
cherry-pick from: https://github.com/linuxdeepin/dtkwidget/commit/2c3b351b439f56a9373538e8c6b6660167eb378d

pms: BUG-310879