### PR TITLE
feat: add window radius control for treeland platform

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatforminterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatforminterface.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -16,6 +16,18 @@ DGUI_BEGIN_NAMESPACE
 
 DTreelandPlatformInterface::DTreelandPlatformInterface(DPlatformTheme *platformTheme)
     : DPlatformInterface(platformTheme)
+    , m_manager(nullptr)
+    , m_activeColor(QColor())
+    , m_titleHeight(0)
+    , m_fontName(QByteArray())
+    , m_monoFontName(QByteArray())
+    , m_iconThemeName(QByteArray())
+    , m_cursorThemeName(QByteArray())
+    , m_fontPointSize(0.0)
+    , m_windowRadius(0)
+    , m_scrollBarPolicy(0)
+    , m_themeName(QByteArray())
+    , m_blurOpacity(0)
 {
     m_manager = PersonalizationManager::instance();
     connect(m_manager, &PersonalizationManager::activeChanged, this, [this](){
@@ -63,6 +75,23 @@ QColor DTreelandPlatformInterface::activeColor() const
 QByteArray DTreelandPlatformInterface::themeName() const
 {
     return m_themeName;
+}
+
+int DTreelandPlatformInterface::windowRadius() const
+{
+    return m_windowRadius;
+}
+
+int DTreelandPlatformInterface::windowRadius(int defaultValue) const
+{
+    return m_windowRadius > 0 ? m_windowRadius : defaultValue;
+}
+
+void DTreelandPlatformInterface::setWindowRadius(int windowRadius)
+{
+    if (m_appearanceContext) {
+        m_appearanceContext->set_round_corner_radius(windowRadius);
+    }
 }
 
 void DTreelandPlatformInterface::setIconThemeName(const QByteArray &iconThemeName)

--- a/src/plugins/platform/treeland/dtreelandplatforminterface.h
+++ b/src/plugins/platform/treeland/dtreelandplatforminterface.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -34,6 +34,11 @@ public:
     qreal fontPointSize() const override;
     QColor activeColor() const override;
     QByteArray themeName() const override;
+
+    int windowRadius() const override;
+    int windowRadius(int defaultValue = 12) const override;
+
+    void setWindowRadius(int windowRadius) override;
 
     void setIconThemeName(const QByteArray &iconThemeName) override;
     void setFontName(const QByteArray &fontName) override;


### PR DESCRIPTION
1. Add windowRadius property getter and setter to DTreelandPlatformInterface
2. Implement window radius getter with optional default value support
3. Add setter that forwards to appearance context's set_round_corner_radius method
4. Update header file with new method declarations and overrides

Log: Added window radius control feature for treeland platform

Influence:
1. Test windowRadius() returns correct value after setting
2. Test windowRadius(defaultValue) returns default when no radius set
3. Test setWindowRadius(radius) properly updates appearance context
4. Verify radius value persists across window operations
5. Ensure backward compatibility with existing code

feat: 为 treeland 平台添加窗口圆角控制功能

1. 为 DTreelandPlatformInterface 添加窗口圆角属性的获取和设置方法
2. 实现支持默认值的窗口圆角获取函数
3. 添加通过外观上下文设置圆角半径的功能

Log: 新增 treeland 平台窗口圆角控制功能

Influence:
1. 测试 windowRadius() 在设置后返回正确值
2. 测试 windowRadius(defaultValue) 在未设置时返回默认值
3. 测试 setWindowRadius(radius) 正确更新外观上下文
4. 验证圆角值在窗口操作中保持持久性
5. 确保与现有代码的向后兼容性

PMS: BUG-296897