### PR TITLE
fix: use active color as fallback for dark active color in treeland

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatforminterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatforminterface.cpp
@@ -72,6 +72,12 @@ QColor DTreelandPlatformInterface::activeColor() const
     return m_activeColor;
 }
 
+QColor DTreelandPlatformInterface::darkActiveColor() const
+{
+    // treeland does not provide dark active color, return active color as fallback
+    return m_activeColor;
+}
+
 QByteArray DTreelandPlatformInterface::themeName() const
 {
     return m_themeName;

--- a/src/plugins/platform/treeland/dtreelandplatforminterface.h
+++ b/src/plugins/platform/treeland/dtreelandplatforminterface.h
@@ -33,6 +33,7 @@ public:
     QByteArray monoFontName() const override;
     qreal fontPointSize() const override;
     QColor activeColor() const override;
+    QColor darkActiveColor() const override;
     QByteArray themeName() const override;
 
     int windowRadius() const override;


### PR DESCRIPTION
Treeland platform does not provide a separate dark active color
property. When the system theme is set to dark mode, the dark active
color was returning an invalid default value, causing the active color
to appear blank or invisible. This fix returns the regular active color
as a fallback, ensuring consistent visual appearance in dark themes.

Log: Fixed dark active color display issue in treeland platform

Influence:
1. Test active color display in light theme mode
2. Test active color display in dark theme mode
3. Verify that active color is visible and correct in both themes
4. Check color consistency when switching between light and dark themes

fix: 修复treeland平台暗色主题下活动色无效的问题

Treeland平台没有提供独立的暗色主题活动色属性。当系统主题切换为暗色模式
时，暗色活动色返回了无效的默认值，导致活动色显示为空白或不可见。此修复将
常规活动色作为暗色活动色的回退值，确保在暗色主题下保持一致的视觉表现。

Log: 修复treeland平台暗色主题活动色显示问题

Influence:
1. 测试浅色主题模式下的活动色显示
2. 测试暗色主题模式下的活动色显示
3. 验证两种主题下活动色均可见且正确
4. 检查在切换深浅色主题时颜色的表现一致性

PMS: BUG-344937
