### PR TITLE
feat(wm-helper): support system window menu on treeland/wayland

### DIFF
--- a/src/kernel/dwindowmanagerhelper.cpp
+++ b/src/kernel/dwindowmanagerhelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -26,6 +26,10 @@
 
 #ifndef DTK_DISABLE_TREELAND
 #include "plugins/platform/treeland/dtreelandwindowmanagerhelper.h"
+#include <private/qguiapplication_p.h>
+#include <private/qwaylandwindow_p.h>
+#include <private/qwaylandshellsurface_p.h>
+#include <private/qwaylandintegration_p.h>
 #endif
 
 DGUI_BEGIN_NAMESPACE
@@ -524,6 +528,20 @@ void DWindowManagerHelper::setWmClassName(const QByteArray &name)
  */
 void DWindowManagerHelper::popupSystemWindowMenu(const QWindow *window)
 {
+#ifndef DTK_DISABLE_TREELAND
+    if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
+        if (window && window->handle()) {
+            if (auto *wlWindow = dynamic_cast<QtWaylandClient::QWaylandWindow*>(window->handle())) {
+                if (auto *shellSurface = wlWindow->shellSurface()) {
+                    auto *wlIntegration = static_cast<QtWaylandClient::QWaylandIntegration*>(
+                        QGuiApplicationPrivate::platformIntegration());
+                    shellSurface->showWindowMenu(wlIntegration->display()->defaultInputDevice());
+                }
+            }
+        }
+        return;
+    }
+#endif
     return callPlatformFunction<void, void(*)(quint32)>(_popupSystemWindowMenu, quint32(window->handle()->winId()));
 }
 


### PR DESCRIPTION
1. Add Wayland-specific path for popupSystemWindowMenu
2. Show window menu via QWaylandShellSurface for treeland compositor
3. Include necessary Qt Wayland private headers

Log: Add Wayland window menu support for treeland compositor

feat(wm-helper): 支持 treeland/wayland 系统窗口菜单

1. 为 popupSystemWindowMenu 添加 Wayland 专用路径
2. 通过 QWaylandShellSurface 为 treeland 合成器显示窗口菜单
3. 引入必要的 Qt Wayland 私有头文件

Log: 为 treeland 合成器添加 Wayland 窗口菜单支持
PMS: TASK-389419