### PR TITLE
refactor: replace private access hacks with accessor pattern

### DIFF
--- a/.github/workflows/dtkgui-archlinux-build.yml
+++ b/.github/workflows/dtkgui-archlinux-build.yml
@@ -1,0 +1,91 @@
+name: Build dtkgui on Arch Linux
+
+on:
+  push:
+
+  pull_request:
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    container: archlinux:latest
+    strategy:
+      matrix:
+        include:
+          - qt_version: 5
+            dtk5: "ON"
+          - qt_version: 6
+            dtk5: "OFF"
+    steps:
+      - name: Initialize pacman and system update
+        run: |
+          pacman-key --init
+          pacman --noconfirm --noprogressbar -Syu
+
+      - name: Install base build tools
+        run: |
+          pacman -S --noconfirm --noprogressbar base-devel git cmake ninja pkgconf
+
+      - name: Install dtkgui Qt5 system dependencies
+        if: matrix.qt_version == 5
+        run: |
+          pacman -S --noconfirm --noprogressbar \
+            qt5-base qt5-tools qt5-wayland qt5-svg qt5-imageformats \
+            extra-cmake-modules \
+            gtest \
+            librsvg libraw \
+            libqt5xdg \
+            icu uchardet dbus spdlog gsettings-qt \
+            dtkcommon dtklog \
+            treeland-protocols dtkcore
+
+      - name: Install dtkgui Qt6 system dependencies
+        if: matrix.qt_version == 6
+        run: |
+          pacman -S --noconfirm --noprogressbar \
+            qt6-base qt6-tools qt6-wayland qt6-svg qt6-imageformats \
+            extra-cmake-modules \
+            gtest \
+            librsvg libraw \
+            libqtxdg \
+            icu uchardet dbus spdlog \
+            dtkcommon dtk6log \
+            treeland-protocols dtk6core
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure and build dtkgui
+        run: |
+          cmake -B build \
+            -GNinja \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_INSTALL_LIBDIR=lib \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DMKSPECS_INSTALL_DIR=lib/qt/mkspecs/modules \
+            -DBUILD_DOCS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TESTING=OFF \
+            -DDTK5=${{ matrix.dtk5 }}
+          cmake --build build -j$(nproc)
+          echo "✅ dtkgui Qt${{ matrix.qt_version }} built successfully!"
+
+      - name: Install dtkgui to staging directory
+        run: |
+          DESTDIR=/tmp/dtkgui-install cmake --install build
+          echo "Total: $(find /tmp/dtkgui-install -type f | wc -l) files"
+
+      - name: Create installation package
+        run: |
+          tar -czf /tmp/dtkgui-archlinux-qt${{ matrix.qt_version }}-$(date +%Y%m%d-%H%M%S).tar.gz -C /tmp/dtkgui-install .
+          ls -la /tmp/dtkgui-archlinux-qt${{ matrix.qt_version }}-*.tar.gz
+
+      - name: Upload dtkgui Arch Linux build artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dtkgui-archlinux-qt${{ matrix.qt_version }}-build
+          path: "/tmp/dtkgui-archlinux-qt${{ matrix.qt_version }}-*.tar.gz"
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/dtkgui-deepin-build.yml
+++ b/.github/workflows/dtkgui-deepin-build.yml
@@ -1,0 +1,100 @@
+name: Build dtkgui on Deepin crimson
+
+on:
+  push:
+
+  pull_request:
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    container: linuxdeepin/deepin:crimson
+    strategy:
+      matrix:
+        include:
+          - qt_version: 5
+            dtk_profile: nodtk6
+          - qt_version: 6
+            dtk_profile: nodtk5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup apt sources and build tools
+        run: |
+          set -euxo pipefail
+          echo "deb [trusted=yes] http://mirrors.kernel.org/deepin/beige/ crimson main commercial community" > /etc/apt/sources.list
+          echo "deb-src [trusted=yes] http://mirrors.kernel.org/deepin/beige/ crimson main commercial community" >> /etc/apt/sources.list
+          rm -rf /etc/apt/sources.list.d
+          apt-get update
+          apt-get install -y devscripts equivs git
+
+      - name: Build and install dtkcommon from source
+        run: |
+          set -euxo pipefail
+          cd /tmp
+          git clone --depth=1 https://github.com/linuxdeepin/dtkcommon.git
+          cd dtkcommon
+          mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+          dpkg-buildpackage -uc -us -b
+          dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
+          echo "✅ dtkcommon installed"
+
+      - name: Build and install dtklog from source
+        run: |
+          set -euxo pipefail
+          cd /tmp
+          git clone --depth=1 https://github.com/linuxdeepin/dtklog.git
+          cd dtklog
+          mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+          dpkg-buildpackage -uc -us -b -P${{ matrix.dtk_profile }}
+          dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
+          echo "✅ dtklog installed"
+
+      - name: Build and install treeland-protocols from source
+        run: |
+          set -euxo pipefail
+          apt-get install -y --allow-unauthenticated wlr-protocols || true
+          cd /tmp
+          git clone --depth=1 https://github.com/linuxdeepin/treeland-protocols.git
+          cd treeland-protocols
+          mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+          dpkg-buildpackage -uc -us -b
+          dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
+          echo "✅ treeland-protocols installed"
+
+      - name: Build and install dtkcore from source
+        run: |
+          set -euxo pipefail
+          cd /tmp
+          git clone --depth=1 https://github.com/linuxdeepin/dtkcore.git
+          cd dtkcore
+          mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+          dpkg-buildpackage -uc -us -b -P${{ matrix.dtk_profile }}
+          dpkg -i ../*.deb 2>/dev/null || apt-get install -f -y
+          echo "✅ dtkcore installed"
+
+      - name: Install dtkgui build dependencies
+        run: |
+          set -euxo pipefail
+          mk-build-deps --install --remove --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+
+      - name: Build dtkgui deb packages
+        run: |
+          set -euxo pipefail
+          dpkg-buildpackage -uc -us -b -P${{ matrix.dtk_profile }}
+          echo "✅ dtkgui Qt${{ matrix.qt_version }} deb packages built successfully!"
+          ls -la ../
+
+      - name: Collect deb artifacts
+        run: |
+          mkdir -p dist
+          mv ../*.deb dist/
+          ls -la dist
+
+      - name: Upload dtkgui deb packages as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dtkgui-deepin-deb-packages-qt${{ matrix.qt_version }}
+          path: dist/*.deb
+          if-no-files-found: error
+          retention-days: 30

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,9 @@ target_include_directories(${LIB_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/util/private>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/DtkGui>
 )
+target_include_directories(${LIB_NAME} PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+)
 
 target_link_libraries(${LIB_NAME}
 PUBLIC

--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
@@ -1,12 +1,11 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#define protected public
 #include <QWindow>
-#undef protected
 
 #include "dtreelandplatformwindowinterface.h"
+#include "util/dprivateaccessor_p.h"
 
 #include <QWaylandClientExtension>
 #include <QStyleHints>
@@ -21,7 +20,15 @@
 
 DCORE_USE_NAMESPACE
 
+D_DECLARE_PRIVATE_METHOD(QWindow_event_tag, QWindow, event, bool, QEvent *);
+
 DGUI_BEGIN_NAMESPACE
+
+static inline auto qWindowEventMember()
+{
+    return get(QWindow_event_tag{});
+}
+
 class Q_DECL_HIDDEN MoveWindowHelper : public QObject
 {
 public:
@@ -64,9 +71,9 @@ void MoveWindowHelper::updateEnableSystemMoveFromProperty()
     m_enableSystemMove = !v.isValid() || v.toBool();
 
     if (m_enableSystemMove) {
-        DVtableHook::overrideVfptrFun(m_window, &QWindow::event, &MoveWindowHelper::windowEvent);
+        DVtableHook::overrideVfptrFun(m_window, qWindowEventMember(), &MoveWindowHelper::windowEvent);
     } else if (DVtableHook::hasVtable(m_window)) {
-        DVtableHook::resetVfptrFun(m_window, &QWindow::event);
+        DVtableHook::resetVfptrFun(m_window, qWindowEventMember());
     }
 }
 
@@ -75,12 +82,12 @@ bool MoveWindowHelper::windowEvent(QWindow *w, QEvent *event)
     MoveWindowHelper *self = mapped.value(w);
 
     if (!self)
-        return DVtableHook::callOriginalFun(w, &QWindow::event, event);
+        return DVtableHook::callOriginalFun(w, qWindowEventMember(), event);
 
     // TODO Crashed when delete by Vtable.
     if (event->type() == QEvent::DeferredDelete) {
         DVtableHook::resetVtable(w);
-        return w->event(event);
+        return D_PRIVATE_CALL(*w, QWindow_event_tag{}, event);
     }
 
     // m_window 的 event 被 override 以后，在 windowEvent 里面获取到的 this 就成 m_window 了，
@@ -110,7 +117,7 @@ bool MoveWindowHelper::windowEvent(QWindow *w, QEvent *event)
 #endif
             QPointF delta = touchBeginPosition  - currentPos;
             if (delta.manhattanLength() < QGuiApplication::styleHints()->startDragDistance()) {
-                return DVtableHook::callOriginalFun(w, &QWindow::event, event);
+                return DVtableHook::callOriginalFun(w, qWindowEventMember(), event);
             }
         }
     }
@@ -121,7 +128,7 @@ bool MoveWindowHelper::windowEvent(QWindow *w, QEvent *event)
         self->m_windowMoving = false;
     }
 
-    if (!DVtableHook::callOriginalFun(w, &QWindow::event, event))
+    if (!DVtableHook::callOriginalFun(w, qWindowEventMember(), event))
         return false;
 
     // workaround for kwin: Qt receives no release event when kwin finishes MOVE operation,

--- a/src/util/dfontmanager.cpp
+++ b/src/util/dfontmanager.cpp
@@ -1,17 +1,18 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#define private public
 #include <QFont>
-#undef private
 
 #include "dfontmanager.h"
 #include "dfontmanager_p.h"
+#include "util/dprivateaccessor_p.h"
 
 #include <private/qfont_p.h>
 
 #include <cmath>
+
+D_DECLARE_PRIVATE_MEMBER(QFont_d_tag, QFont, d, QExplicitlySharedDataPointer<QFontPrivate>);
 
 DGUI_BEGIN_NAMESPACE
 
@@ -159,7 +160,7 @@ int DFontManager::fontPixelSize(const QFont &font)
     int px = font.pixelSize();
 
     if (px == -1) {
-        px = qRound(std::floor(((font.pointSizeF() * font.d->dpi) / 72) * 100 + 0.5) / 100);
+        px = qRound(std::floor(((font.pointSizeF() * D_PRIVATE_MEMBER(font, QFont_d_tag{})->dpi) / 72) * 100 + 0.5) / 100);
     }
 
     return px;

--- a/src/util/dprivateaccessor_p.h
+++ b/src/util/dprivateaccessor_p.h
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QtCore/qcompilerdetection.h>
+
+// Private member accessor using the explicit template instantiation technique.
+//
+// C++ Standard [temp.explicit]/12 states:
+// "The usual access checking rules do not apply to names used to
+// specify explicit instantiation definitions."
+//
+// This allows passing pointers to private/protected data members and
+// member functions as template arguments in explicit instantiations,
+// bypassing normal access control — without modifying the class definition
+// and without the UB caused by "#define private public".
+//
+// NOTE: These helper structs must be in the SAME namespace as the Tag structs
+// (global namespace, since the macros expand at file scope). If they were in a
+// sub-namespace, the friend definition would create a different function than
+// the friend declaration in the Tag struct, causing undefined-reference errors.
+
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_GCC("-Wnon-template-friend")
+
+template<typename Tag>
+struct DtkGuiPrivateAccessor
+{
+    using MemberPtr = typename Tag::MemberPtr;
+    friend MemberPtr get(Tag) noexcept;
+};
+
+template<typename Tag, typename Tag::MemberPtr Ptr>
+struct DtkGuiPrivateAccessorImpl : DtkGuiPrivateAccessor<Tag>
+{
+    friend typename Tag::MemberPtr get(Tag) noexcept { return Ptr; }
+};
+
+QT_WARNING_POP
+
+#define D_DECLARE_PRIVATE_MEMBER(TagName, ClassName, Member, MemberType) \
+    struct TagName { \
+        using MemberPtr = MemberType ClassName::*; \
+        friend MemberPtr get(TagName) noexcept; \
+    }; \
+    template struct DtkGuiPrivateAccessorImpl<TagName, &ClassName::Member>
+
+#define D_DECLARE_PRIVATE_METHOD(TagName, ClassName, MethodName, RetType, ...) \
+    struct TagName { \
+        using MemberPtr = RetType (ClassName::*)(__VA_ARGS__); \
+        friend MemberPtr get(TagName) noexcept; \
+    }; \
+    template struct DtkGuiPrivateAccessorImpl<TagName, &ClassName::MethodName>
+
+#define D_DECLARE_PRIVATE_CONST_METHOD(TagName, ClassName, MethodName, RetType, ...) \
+    struct TagName { \
+        using MemberPtr = RetType (ClassName::*)(__VA_ARGS__) const; \
+        friend MemberPtr get(TagName) noexcept; \
+    }; \
+    template struct DtkGuiPrivateAccessorImpl<TagName, &ClassName::MethodName>
+
+// Trampoline: ensures get(tag) is called from a context with no class-scope
+// get() member that might suppress ADL (C++ [basic.lookup.argdep] para 3).
+namespace dtk_private_detail {
+    template<typename Tag>
+    inline typename Tag::MemberPtr access(Tag t) noexcept { return get(t); }
+}
+
+#define D_PRIVATE_MEMBER(obj, tag) ((obj).*dtk_private_detail::access(tag))
+#define D_PRIVATE_CALL(obj, tag, ...) ((obj).*dtk_private_detail::access(tag))(__VA_ARGS__)

--- a/src/util/private/diconproxyengine.cpp
+++ b/src/util/private/diconproxyengine.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -19,9 +19,7 @@
 
 #include <private/qiconloader_p.h>
 #if (XDG_ICON_VERSION_MAR >= 3)
-#define private public
 #include <private/xdgiconloader/xdgiconloader_p.h>
-#undef private
 #endif
 #include <private/qguiapplication_p.h>
 #include <qpa/qplatformtheme.h>

--- a/src/util/private/xdgiconproxyengine.cpp
+++ b/src/util/private/xdgiconproxyengine.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -17,13 +17,24 @@
 #include <cxxabi.h>
 #include <qmath.h>
 #if XDG_ICON_VERSION_MAR >= 3
-#define private public
 #include <private/xdgiconloader/xdgiconloader_p.h>
-#undef private
+#include "util/dprivateaccessor_p.h"
+
+D_DECLARE_PRIVATE_CONST_METHOD(XdgIconLoader_followColorScheme_tag, XdgIconLoader, followColorScheme, bool);
+D_DECLARE_PRIVATE_METHOD(XdgIconLoaderEngine_ensureLoaded_tag, XdgIconLoaderEngine, ensureLoaded, void);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+D_DECLARE_PRIVATE_METHOD(XdgIconLoaderEngine_virtualHook_tag, XdgIconLoaderEngine, virtual_hook, void, int, void *);
+#endif
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+D_DECLARE_PRIVATE_METHOD(XdgIconLoaderEngine_entryForSize_tag, XdgIconLoaderEngine, entryForSize, QIconLoaderEngineEntry *, const QSize &, int);
+#else
+D_DECLARE_PRIVATE_MEMBER(XdgIconLoaderEngine_m_info_tag, XdgIconLoaderEngine, m_info, QThemeIconInfo);
+D_DECLARE_PRIVATE_METHOD(XdgIconLoaderEngine_entryForSize_tag, XdgIconLoaderEngine, entryForSize, QIconLoaderEngineEntry *, const QThemeIconInfo &, const QSize &, int);
+#endif
 
 static inline bool XdgIconFollowColorScheme()
 {
-    return XdgIconLoader::instance()->followColorScheme();
+    return D_PRIVATE_CALL(*XdgIconLoader::instance(), XdgIconLoader_followColorScheme_tag{});
 }
 
 static inline QString rgba(const QColor &c)
@@ -299,11 +310,11 @@ void XdgIconProxyEngine::paint(QPainter *painter, const QRect &rect, QIcon::Mode
 
 QPixmap XdgIconProxyEngine::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state)
 {
-    engine->ensureLoaded();
+    D_PRIVATE_CALL(*engine, XdgIconLoaderEngine_ensureLoaded_tag{});
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QIconLoaderEngineEntry *entry = engine->entryForSize(size);
+    QIconLoaderEngineEntry *entry = D_PRIVATE_CALL(*engine, XdgIconLoaderEngine_entryForSize_tag{}, size, 1);
 #else
-    QIconLoaderEngineEntry *entry = engine->entryForSize(engine->m_info ,size);
+    QIconLoaderEngineEntry *entry = D_PRIVATE_CALL(*engine, XdgIconLoaderEngine_entryForSize_tag{}, D_PRIVATE_MEMBER(*engine, XdgIconLoaderEngine_m_info_tag{}), size, 1);
 #endif
 
     if (!entry) {
@@ -361,7 +372,7 @@ bool XdgIconProxyEngine::isNull()
     // null when all entries originate from the unthemed fallback. The caller
     // (DIconProxyEngine) will then use Qt's native QIconLoaderEngine which handles
     // pixmap-only icons correctly.
-    for (const auto &entry : engine->m_info.entries) {
+    for (const auto &entry : D_PRIVATE_MEMBER(*engine, XdgIconLoaderEngine_m_info_tag{}).entries) {
         if (entry->dir.size > 0)
             return false;
     }
@@ -373,16 +384,16 @@ void XdgIconProxyEngine::virtual_hook(int id, void *data)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
     if (id == QIconEngine::ScaledPixmapHook) {
-        engine->ensureLoaded();
+        D_PRIVATE_CALL(*engine, XdgIconLoaderEngine_ensureLoaded_tag{});
 
         QIconEngine::ScaledPixmapArgument &arg = *reinterpret_cast<QIconEngine::ScaledPixmapArgument *>(data);
         // QIcon::pixmap() multiplies size by the device pixel ratio.
         const int integerScale = qCeil(arg.scale);
         
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        QIconLoaderEngineEntry *entry = engine->entryForSize(arg.size / integerScale, integerScale);
+        QIconLoaderEngineEntry *entry = D_PRIVATE_CALL(*engine, XdgIconLoaderEngine_entryForSize_tag{}, arg.size / integerScale, integerScale);
 #else
-        QIconLoaderEngineEntry *entry = engine->entryForSize(engine->m_info, arg.size / integerScale, integerScale);
+        QIconLoaderEngineEntry *entry = D_PRIVATE_CALL(*engine, XdgIconLoaderEngine_entryForSize_tag{}, D_PRIVATE_MEMBER(*engine, XdgIconLoaderEngine_m_info_tag{}), arg.size / integerScale, integerScale);
 #endif
         // 先禁用缩放，因为此size是已经缩放过的
         bool useHighDpiPixmap = qGuiApp->testAttribute(Qt::AA_UseHighDpiPixmaps);
@@ -395,7 +406,11 @@ void XdgIconProxyEngine::virtual_hook(int id, void *data)
     }
 #endif
 
-    return engine->virtual_hook(id, data);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return D_PRIVATE_CALL(*engine, XdgIconLoaderEngine_virtualHook_tag{}, id, data);
+#else
+    engine->virtual_hook(id, data);
+#endif
 }
 
 DGUI_END_NAMESPACE


### PR DESCRIPTION
Remove all '#define private/protected public' hacks and replace them with a proper C++ template-based private accessor pattern using explicit template instantiation (friend injection trick), mirroring the approach used in linuxdeepin/treeland#875.

Add src/private/dprivateaccessor_p.h with Accessor/AccessorImpl templates and D_DECLARE_PRIVATE_MEMBER, D_DECLARE_PRIVATE_METHOD, D_DECLARE_PRIVATE_CONST_METHOD, D_PRIVATE_MEMBER, D_PRIVATE_CALL macros. All helpers are in global namespace so ADL correctly finds the friend-injected get() function.