### PR TITLE
feat: add HasInWindowBlur attribute to DGuiApplicationHelper

### DIFF
--- a/include/kernel/dguiapplicationhelper.h
+++ b/include/kernel/dguiapplicationhelper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -63,6 +63,7 @@ public:
         IsWaylandPlatform       = ReadOnlyLimit << 6,
         IsTreelandPlatform Q_DECL_ENUMERATOR_DEPRECATED_X("Use DGuiApplicationHelper::IsWaylandPlatform instead") = IsWaylandPlatform,
         HasAnimations            = ReadOnlyLimit << 7,
+        HasInWindowBlur          = ReadOnlyLimit << 8,
     };
     Q_ENUM(Attribute)
     Q_DECLARE_FLAGS(Attributes, Attribute)

--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -124,6 +124,7 @@ Q_GLOBAL_STATIC(DFontManager, _globalFM)
 #define WINDOW_THEME_KEY "_d_platform_theme"
 
 #define DTK_ANIMATIONS_ENV "D_DTK_DISABLE_ANIMATIONS"
+#define DTK_DISABLE_INWINDOWBLUR_ENV "D_DTK_DISABLE_INWINDOWBLUR"
 Q_GLOBAL_STATIC_WITH_ARGS(OrgDeepinDTKPreference, _d_dconfig, (DTK_CORE_NAMESPACE::DConfig::globalThread(), nullptr,
                                                                "org.deepin.dtk.preference", DTK_CORE_NAMESPACE::DSGApplication::id(), {}, false, nullptr))
 
@@ -1885,6 +1886,13 @@ bool DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::Attribute attri
             return false;
 
         return _d_dconfig->enableDtkAnimations();
+    }
+    case HasInWindowBlur: {
+        static bool isDisable = qEnvironmentVariableIsSet(DTK_DISABLE_INWINDOWBLUR_ENV);
+        if (isDisable)
+            return false;
+
+        return !_d_dconfig->disableInWindowBlur();
     }
     default:
         return DGuiApplicationHelperPrivate::attributes.testFlag(attribute);


### PR DESCRIPTION
## Summary

- Add new `HasInWindowBlur` attribute to `DGuiApplicationHelper::Attribute` enum
- Support environment variable `D_DTK_DISABLE_INWINDOWBLUR` to disable InWindowBlur
- Read `disableInWindowBlur` from DConfig for runtime control

## Issue

https://pms.uniontech.com/task-view-390117.html

## Test Plan

- [ ] Test HasInWindowBlur returns true by default
- [ ] Test environment variable D_DTK_DISABLE_INWINDOWBLUR disables InWindowBlur
- [ ] Test DConfig disableInWindowBlur setting works correctly