### PR TITLE
fix: use q_func() as signal receiver to ensure palette type change runs on main thread

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -489,7 +489,7 @@ void DGuiApplicationHelperPrivate::initPaletteType() const
     int ct = dconfig.value("themeType", DGuiApplicationHelper::UnknownType).toInt();
     const_cast<DGuiApplicationHelperPrivate *>(this)->setPaletteType(DGuiApplicationHelper::ColorType(ct), false);
 
-    QObject::connect(_d_dconfig.operator ()(), &OrgDeepinDTKPreference::themeTypeChanged, _d_dconfig, [applyThemeType] {
+    QObject::connect(_d_dconfig.operator ()(), &OrgDeepinDTKPreference::themeTypeChanged, q_func(), [applyThemeType] {
         applyThemeType(true);
     });
 }


### PR DESCRIPTION
## Summary

- Fix thread affinity violation: `_d_dconfig` lives on `DConfig::globalThread()`, so using it as receiver for `themeTypeChanged` signal causes the lambda to execute on a background thread
- Change receiver from `_d_dconfig` to `q_func()` (DGuiApplicationHelper, lives on main thread) so `Qt::AutoConnection` automatically uses `QueuedConnection` when signal is emitted from a different thread
- This prevents the error: `QObject: Cannot create children for a parent that is in a different thread (Parent is QStyleHints...)`

## Test

Related issue: WM-23