### PR TITLE
fix: prevent window blur loss on destruction in treeland platform

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
@@ -220,7 +220,10 @@ DTreeLandPlatformWindowHelper::DTreeLandPlatformWindowHelper(QWindow *window)
 
 DTreeLandPlatformWindowHelper::~DTreeLandPlatformWindowHelper()
 {
-    // see tst_qwindow.cpp tst_QWindow::qobject_castOnDestruction()
+    if (m_windowContext) {
+        m_windowContext->deleteLater();
+        m_windowContext = nullptr;
+    }
     windowMap.remove(static_cast<QWindow*>(parent()));
 }
 

--- a/src/plugins/platform/treeland/personalizationwaylandclientextension.cpp
+++ b/src/plugins/platform/treeland/personalizationwaylandclientextension.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -73,6 +73,18 @@ PersonalizationWindowContext::PersonalizationWindowContext(struct ::treeland_per
 
 }
 
+PersonalizationWindowContext::~PersonalizationWindowContext()
+{
+    if (isInitialized())
+        destroy();
+}
+
+PersonalizationAppearanceContext::~PersonalizationAppearanceContext()
+{
+    if (isInitialized())
+        destroy();
+}
+
 PersonalizationAppearanceContext::PersonalizationAppearanceContext(struct ::treeland_personalization_appearance_context_v1 *context, DTreelandPlatformInterface *interface)
     : QWaylandClientExtensionTemplate<PersonalizationAppearanceContext>(treeland_personalization_appearance_context_v1_interface.version)
     , QtWayland::treeland_personalization_appearance_context_v1(context)
@@ -116,6 +128,12 @@ void PersonalizationAppearanceContext::treeland_personalization_appearance_conte
 void PersonalizationAppearanceContext::treeland_personalization_appearance_context_v1_window_opacity(uint32_t opacity)
 {
     m_interface->m_blurOpacity = opacity;
+}
+
+PersonalizationFontContext::~PersonalizationFontContext()
+{
+    if (isInitialized())
+        destroy();
 }
 
 PersonalizationFontContext::PersonalizationFontContext(struct ::treeland_personalization_font_context_v1 *context, DTreelandPlatformInterface *interface)

--- a/src/plugins/platform/treeland/personalizationwaylandclientextension.h
+++ b/src/plugins/platform/treeland/personalizationwaylandclientextension.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -48,6 +48,7 @@ class PersonalizationWindowContext : public QWaylandClientExtensionTemplate<Pers
     Q_OBJECT
 public:
     explicit PersonalizationWindowContext(struct ::treeland_personalization_window_context_v1 *context);
+    ~PersonalizationWindowContext() override;
 };
 
 class PersonalizationAppearanceContext : public QWaylandClientExtensionTemplate<PersonalizationAppearanceContext>,
@@ -56,6 +57,7 @@ class PersonalizationAppearanceContext : public QWaylandClientExtensionTemplate<
     Q_OBJECT
 public:
     explicit PersonalizationAppearanceContext(struct ::treeland_personalization_appearance_context_v1 *context, DTreelandPlatformInterface *interface);
+    ~PersonalizationAppearanceContext() override;
 
 protected:
     void treeland_personalization_appearance_context_v1_round_corner_radius(int32_t radius) override;
@@ -73,6 +75,7 @@ class PersonalizationFontContext : public QWaylandClientExtensionTemplate<Person
     Q_OBJECT
 public:
     explicit PersonalizationFontContext(struct ::treeland_personalization_font_context_v1 *context, DTreelandPlatformInterface *interface);
+    ~PersonalizationFontContext() override;
 
 protected:
     void treeland_personalization_font_context_v1_font(const QString &font_name) override;


### PR DESCRIPTION
1. Added destructor cleanup for PersonalizationWindowContext,
PersonalizationAppearanceContext, and PersonalizationFontContext to
properly destroy wayland protocol objects
2. Added deferred deletion of m_windowContext in
DTreeLandPlatformWindowHelper destructor to prevent dangling pointer
access
3. Fixed the intermittent window blur loss issue by ensuring wayland
objects are properly cleaned up before the parent window is removed from
the window map

Log: Fixed intermittent window blur loss issue in treeland

Influence:
1. Test window creation and destruction with blur effects enabled
2. Verify window blur effect persists during normal usage
3. Test rapid window open/close cycles to reproduce the intermittent
blur loss
4. Verify no crashes or memory leaks when windows are destroyed
5. Test on treeland platform with multiple windows and frequent window
operations

fix: 修复treeland平台上窗口销毁时模糊效果丢失问题

1. 为PersonalizationWindowContext、PersonalizationAppearanceContext和
PersonalizationFontContext添加析构函数，确保正确销毁wayland协议对象
2. 在DTreeLandPlatformWindowHelper析构函数中添加m_windowContext的延迟删
除，防止悬空指针访问
3. 通过在从窗口映射表中移除父窗口前清理wayland对象，修复间歇性窗口模糊丢
失问题

Log: 修复treeland平台上窗口模糊偶现丢失问题

Influence:
1. 测试开启模糊效果时的窗口创建和销毁
2. 验证正常使用时窗口模糊效果持续保持
3. 测试快速打开/关闭窗口循环以重现间歇性模糊丢失问题
4. 验证窗口销毁时无崩溃或内存泄漏
5. 在treeland平台上使用多个窗口和频繁窗口操作进行测试

PMS: BUG-345489

## Summary by Sourcery

Ensure treeland personalization Wayland client contexts and window helper clean up their resources safely during window destruction to prevent blur effect loss and stability issues.

Bug Fixes:
- Fix intermittent loss of window blur effects on treeland by ensuring personalization Wayland contexts are properly destroyed on teardown.

Enhancements:
- Add destructors to personalization Wayland client contexts to clean up protocol objects safely.
- Defer deletion of DTreeLandPlatformWindowHelper's window context to avoid dangling pointer access during window destruction.