### PR TITLE
feat: add border and shadow support for TreeLand windows

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
@@ -264,15 +264,8 @@ void DTreeLandPlatformWindowHelper::onActiveChanged()
 
 void DTreeLandPlatformWindowHelper::onSurfaceCreated()
 {
-    if (m_isNoTitlebar) {
-        doSetEnabledNoTitlebar();
-    }
-    if (m_radius > 0) {
-        doSetWindowRadius();
-    }
-    if (m_isWindowBlur) {
-        doSetEnabledBlurWindow();
-    }
+    m_dirty = m_initialized;
+    scheduleApply();
 }
 
 void DTreeLandPlatformWindowHelper::onSurfaceDestroyed()
@@ -313,38 +306,87 @@ PersonalizationWindowContext *DTreeLandPlatformWindowHelper::windowContext() con
 
 void DTreeLandPlatformWindowHelper::setEnabledNoTitlebar(bool enable)
 {
-    m_isNoTitlebar = enable;
-    doSetEnabledNoTitlebar();
+    updateFeature(m_noTitlebar, enable, NoTitlebar);
 }
+
 void DTreeLandPlatformWindowHelper::setWindowRadius(int windowRadius)
 {
-    m_radius = windowRadius;
-    doSetWindowRadius();
+    updateFeature(m_radius, windowRadius, Radius);
 }
+
+void DTreeLandPlatformWindowHelper::setBorderWidth(int borderWidth)
+{
+    updateFeature(m_borderWidth, borderWidth, Border);
+}
+
+void DTreeLandPlatformWindowHelper::setBorderColor(const QColor &borderColor)
+{
+    updateFeature(m_borderColor, borderColor, Border);
+}
+
+void DTreeLandPlatformWindowHelper::setShadowRadius(int shadowRadius)
+{
+    updateFeature(m_shadowRadius, shadowRadius, Shadow);
+}
+
+void DTreeLandPlatformWindowHelper::setShadowOffset(const QPoint &shadowOffset)
+{
+    updateFeature(m_shadowOffset, shadowOffset, Shadow);
+}
+
+void DTreeLandPlatformWindowHelper::setShadowColor(const QColor &shadowColor)
+{
+    updateFeature(m_shadowColor, shadowColor, Shadow);
+}
+
 void DTreeLandPlatformWindowHelper::setEnableBlurWindow(bool enableBlurWindow)
 {
-    m_isWindowBlur = enableBlurWindow;
-    doSetEnabledBlurWindow();
+    updateFeature(m_blur, enableBlurWindow, Blur);
 }
 
-void DTreeLandPlatformWindowHelper::doSetEnabledNoTitlebar()
+void DTreeLandPlatformWindowHelper::setPlatformHandle(DPlatformHandle *handle)
 {
-    if (auto context = windowContext()) {
-        context->set_titlebar(m_isNoTitlebar ? PersonalizationWindowContext::enable_mode_disable : PersonalizationWindowContext::enable_mode_enable);
-    }
+    m_platformHandle = handle;
 }
 
-void DTreeLandPlatformWindowHelper::doSetWindowRadius()
+void DTreeLandPlatformWindowHelper::scheduleApply()
 {
-    if (auto context = windowContext()) {
-        context->set_round_corner_radius(m_radius);
-    }
+    if (m_applyScheduled)
+        return;
+    m_applyScheduled = true;
+    QMetaObject::invokeMethod(this, &DTreeLandPlatformWindowHelper::applyPending, Qt::QueuedConnection);
 }
 
-void DTreeLandPlatformWindowHelper::doSetEnabledBlurWindow()
+void DTreeLandPlatformWindowHelper::applyPending()
 {
+    m_applyScheduled = false;
+
     if (auto context = windowContext()) {
-        context->set_blend_mode(m_isWindowBlur ? PersonalizationWindowContext::blend_mode_blur : PersonalizationWindowContext::blend_mode_transparent);
+        if (m_dirty & NoTitlebar) {
+            m_dirty &= ~NoTitlebar;
+            context->set_titlebar(m_noTitlebar ? PersonalizationWindowContext::enable_mode_disable : PersonalizationWindowContext::enable_mode_enable);
+        }
+        if (m_dirty & Radius) {
+            m_dirty &= ~Radius;
+            context->set_round_corner_radius(m_radius);
+        }
+        if (m_dirty & Blur) {
+            m_dirty &= ~Blur;
+            context->set_blend_mode(m_blur ? PersonalizationWindowContext::blend_mode_blur : PersonalizationWindowContext::blend_mode_transparent);
+        }
+        if (m_dirty & Border) {
+            m_dirty &= ~Border;
+            context->set_border(m_borderWidth,
+                                m_borderColor.red(), m_borderColor.green(),
+                                m_borderColor.blue(), m_borderColor.alpha());
+        }
+        if (m_dirty & Shadow) {
+            m_dirty &= ~Shadow;
+            context->set_shadow(m_shadowRadius,
+                                m_shadowOffset.x(), m_shadowOffset.y(),
+                                m_shadowColor.red(), m_shadowColor.green(),
+                                m_shadowColor.blue(), m_shadowColor.alpha());
+        }
     }
 }
 
@@ -355,6 +397,9 @@ DTreeLandPlatformWindowInterface::DTreeLandPlatformWindowInterface(QWindow *wind
     if (!MoveWindowHelper::mapped.value(window)) {
         Q_UNUSED(new MoveWindowHelper(window))
     }
+    if (auto helper = DTreeLandPlatformWindowHelper::get(window)) {
+        helper->setPlatformHandle(platformHandle);
+    }
 }
 
 DTreeLandPlatformWindowInterface::~DTreeLandPlatformWindowInterface()
@@ -363,9 +408,7 @@ DTreeLandPlatformWindowInterface::~DTreeLandPlatformWindowInterface()
 
 void DTreeLandPlatformWindowInterface::setEnabled(bool enabled)
 {
-    if (setEnabledNoTitlebar(enabled)) {
-        return;
-    }
+    setEnabledNoTitlebar(enabled);
 }
 
 bool DTreeLandPlatformWindowInterface::isEnabled() const
@@ -375,56 +418,129 @@ bool DTreeLandPlatformWindowInterface::isEnabled() const
 
 bool DTreeLandPlatformWindowInterface::isEnabledNoTitlebar() const
 {
-    return m_isNoTitlebar;
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return helper->isEnabledNoTitlebar();
+    return false;
 }
 
 bool DTreeLandPlatformWindowInterface::setEnabledNoTitlebar(bool enable)
 {
-    if (m_isNoTitlebar == enable) {
-        return true;
-    }
-    m_isNoTitlebar = enable;
     if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
         helper->setEnabledNoTitlebar(enable);
+        return true;
     }
-    return true;
+    return false;
 }
 
 int DTreeLandPlatformWindowInterface::windowRadius() const
 {
-    return m_radius;
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return helper->windowRadius();
+    return 0;
 }
 
 void DTreeLandPlatformWindowInterface::setWindowRadius(int windowRadius)
 {
-    if (m_radius == windowRadius) {
-        return;
-    }
-    m_radius = windowRadius;
     if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
-        helper->setWindowRadius(m_radius);
+        helper->setWindowRadius(windowRadius);
+        if (m_platformHandle)
+            Q_EMIT m_platformHandle->windowRadiusChanged();
     }
-    if (m_platformHandle) {
-        Q_EMIT m_platformHandle->windowRadiusChanged();
+}
+
+int DTreeLandPlatformWindowInterface::borderWidth() const
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return helper->borderWidth();
+    return 0;
+}
+
+void DTreeLandPlatformWindowInterface::setBorderWidth(int borderWidth)
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
+        helper->setBorderWidth(borderWidth);
+        if (m_platformHandle)
+            Q_EMIT m_platformHandle->borderWidthChanged();
+    }
+}
+
+QColor DTreeLandPlatformWindowInterface::borderColor() const
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return helper->borderColor();
+    return {};
+}
+
+void DTreeLandPlatformWindowInterface::setBorderColor(const QColor &borderColor)
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
+        helper->setBorderColor(borderColor);
+        if (m_platformHandle)
+            Q_EMIT m_platformHandle->borderColorChanged();
+    }
+}
+
+int DTreeLandPlatformWindowInterface::shadowRadius() const
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return helper->shadowRadius();
+    return 0;
+}
+
+void DTreeLandPlatformWindowInterface::setShadowRadius(int shadowRadius)
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
+        helper->setShadowRadius(shadowRadius);
+        if (m_platformHandle)
+            Q_EMIT m_platformHandle->shadowRadiusChanged();
+    }
+}
+
+QPoint DTreeLandPlatformWindowInterface::shadowOffset() const
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return helper->shadowOffset();
+    return {};
+}
+
+void DTreeLandPlatformWindowInterface::setShadowOffset(const QPoint &shadowOffset)
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
+        helper->setShadowOffset(shadowOffset);
+        if (m_platformHandle)
+            Q_EMIT m_platformHandle->shadowOffsetChanged();
+    }
+}
+
+QColor DTreeLandPlatformWindowInterface::shadowColor() const
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return helper->shadowColor();
+    return {};
+}
+
+void DTreeLandPlatformWindowInterface::setShadowColor(const QColor &shadowColor)
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
+        helper->setShadowColor(shadowColor);
+        if (m_platformHandle)
+            Q_EMIT m_platformHandle->shadowColorChanged();
     }
 }
 
 bool DTreeLandPlatformWindowInterface::enableBlurWindow() const
 {
-    return m_isWindowBlur;
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return helper->enableBlurWindow();
+    return false;
 }
 
 void DTreeLandPlatformWindowInterface::setEnableBlurWindow(bool enable)
 {
-    if (m_isWindowBlur == enable) {
-        return;
-    }
-    m_isWindowBlur = enable;
     if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
         helper->setEnableBlurWindow(enable);
-    }
-    if (m_platformHandle) {
-        Q_EMIT m_platformHandle->enableBlurWindowChanged();
+        if (m_platformHandle)
+            Q_EMIT m_platformHandle->enableBlurWindowChanged();
     }
 }
 DGUI_END_NAMESPACE

--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.h
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -6,7 +6,7 @@
 #define DTREELANDPLATFORMWINDOWINTERFACE_H
 
 #include "dtkgui_global.h"
-#include "dtreelandplatforminterface.h"
+#include <QColor>
 #include <QObject>
 #include <QtWaylandClient/private/qwaylandwindow_p.h>
 #include "private/dplatformwindowinterface_p.h"
@@ -19,32 +19,74 @@ public:
     static DTreeLandPlatformWindowHelper *get(QWindow *window);
     ~DTreeLandPlatformWindowHelper() override;
 
+    enum Feature {
+        NoTitlebar  = 1 << 0,
+        Radius      = 1 << 1,
+        Blur        = 1 << 2,
+        Border      = 1 << 3,
+        Shadow      = 1 << 4,
+    };
+    Q_DECLARE_FLAGS(Features, Feature)
+
     QWindow *window() const { return qobject_cast<QWindow *>(parent()); }
     PersonalizationWindowContext *windowContext() const;
 
     void setEnabledNoTitlebar(bool enable);
     void setWindowRadius(int windowRadius);
+    void setBorderWidth(int borderWidth);
+    void setBorderColor(const QColor &borderColor);
+    void setShadowRadius(int shadowRadius);
+    void setShadowOffset(const QPoint &shadowOffset);
+    void setShadowColor(const QColor &shadowColor);
     void setEnableBlurWindow(bool enableBlurWindow);
+    void setPlatformHandle(DPlatformHandle *handle);
+
+    bool isEnabledNoTitlebar() const { return m_noTitlebar; }
+    int windowRadius() const { return m_radius; }
+    int borderWidth() const { return m_borderWidth; }
+    QColor borderColor() const { return m_borderColor; }
+    int shadowRadius() const { return m_shadowRadius; }
+    QPoint shadowOffset() const { return m_shadowOffset; }
+    QColor shadowColor() const { return m_shadowColor; }
+    bool enableBlurWindow() const { return m_blur; }
 
 private slots:
     void onActiveChanged();
     void onSurfaceCreated();
     void onSurfaceDestroyed();
+    void applyPending();
 private:
     explicit DTreeLandPlatformWindowHelper(QWindow *window);
     bool eventFilter(QObject *watched, QEvent *event) override;
     void initWaylandWindow();
+    void scheduleApply();
 
-    void doSetEnabledNoTitlebar();
-    void doSetWindowRadius();
-    void doSetEnabledBlurWindow();
+    template<typename T>
+    void updateFeature(T &member, const T &value, Feature flag) {
+        if (member == value)
+            return;
+        member = value;
+        m_initialized |= flag;
+        m_dirty |= flag;
+        scheduleApply();
+    }
+
 private:
     PersonalizationWindowContext *m_windowContext = nullptr;
     static QMap<QWindow *, DTreeLandPlatformWindowHelper*> windowMap;
+    DPlatformHandle *m_platformHandle = nullptr;
 
-    bool m_isNoTitlebar = false;
-    bool m_isWindowBlur = false;
+    bool m_noTitlebar = false;
+    bool m_blur = false;
     int m_radius = 0;
+    int m_borderWidth = 0;
+    QColor m_borderColor;
+    int m_shadowRadius = 0;
+    QPoint m_shadowOffset;
+    QColor m_shadowColor;
+    Features m_initialized;
+    Features m_dirty;
+    bool m_applyScheduled = false;
 };
 
 class DTreeLandPlatformWindowInterface : public QObject, public DPlatformWindowInterface
@@ -63,14 +105,21 @@ public:
     int windowRadius() const override;
     void setWindowRadius(int windowRadius) override;
 
+    int borderWidth() const override;
+    void setBorderWidth(int borderWidth) override;
+    QColor borderColor() const override;
+    void setBorderColor(const QColor &borderColor) override;
+    int shadowRadius() const override;
+    void setShadowRadius(int shadowRadius) override;
+    QPoint shadowOffset() const override;
+    void setShadowOffset(const QPoint &shadowOffset) override;
+    QColor shadowColor() const override;
+    void setShadowColor(const QColor &shadowColor) override;
+
     bool enableBlurWindow() const override;
     void setEnableBlurWindow(bool enableBlurWindow) override;
-
-private:
-    bool m_isNoTitlebar = false;
-    bool m_isWindowBlur = false;
-    int m_radius = 0;
 };
 
 DGUI_END_NAMESPACE
+
 #endif // DTREELANDPLATFORMWINDOWINTERFACE_H


### PR DESCRIPTION
Implement border width/color and shadow radius/offset/color for TreeLand
platform windows. Refactor the personalization window protocol to use
a unified dirty-flag schedule/apply pattern instead of immediate per-
feature calls. This ensures all window decorations are applied together
after surface creation or property changes.

Log: Added window border and shadow customization for TreeLand

Influence:
1. Test setting border width and color, verify visual appearance
2. Test setting shadow radius, offset, and color, verify correct
rendering
3. Test enabling/disabling no-titlebar mode with borders and shadows
4. Verify that changing multiple properties at once triggers correct
apply
5. Test window resize and surface recreation scenarios for persistence
6. Verify API backward compatibility: existing radius and blur functions
still work

feat: 为 Treeland 窗口添加边框和阴影支持

实现边框宽度/颜色和阴影半径/偏移/颜色。重构个性化窗口协议，使用统一的脏
标志调度/应用模式替代旧的即时逐特性调用。确保所有窗口装饰在表面创建或属
性更改后一起应用。

Log: 新增窗口边框和阴影定制功能

Influence:
1. 测试设置边框宽度和颜色，验证视觉效果
2. 测试设置阴影半径、偏移和颜色，验证正确渲染
3. 测试在启用/禁用无标题栏模式下边框和阴影的表现
4. 验证同时更改多个属性会触发正确的应用
5. 测试窗口大小变化和表面重建场景的持久性
6. 验证 API 向后兼容性：原有的圆角和模糊功能仍然正常工作
