### PR TITLE
feat: add window effect support for treeland platform

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
@@ -344,6 +344,11 @@ void DTreeLandPlatformWindowHelper::setEnableBlurWindow(bool enableBlurWindow)
     updateFeature(m_blur, enableBlurWindow, Blur);
 }
 
+void DTreeLandPlatformWindowHelper::setWindowEffect(DPlatformHandle::EffectScenes effectScene)
+{
+    updateFeature(m_effectScene, effectScene, WindowEffect);
+}
+
 void DTreeLandPlatformWindowHelper::setPlatformHandle(DPlatformHandle *handle)
 {
     m_platformHandle = handle;
@@ -386,6 +391,18 @@ void DTreeLandPlatformWindowHelper::applyPending()
                                 m_shadowOffset.x(), m_shadowOffset.y(),
                                 m_shadowColor.red(), m_shadowColor.green(),
                                 m_shadowColor.blue(), m_shadowColor.alpha());
+        }
+        if (m_dirty & WindowEffect) {
+            m_dirty &= ~WindowEffect;
+            if (m_effectScene.testFlag(DPlatformHandle::EffectNoRadius)) {
+                context->set_round_corner_radius(0);
+            }
+            if (m_effectScene.testFlag(DPlatformHandle::EffectNoShadow)) {
+                context->set_shadow(0, 0, 0, 0, 0, 0, 0);
+            }
+            if (m_effectScene.testFlag(DPlatformHandle::EffectNoBorder)) {
+                context->set_border(0, 0, 0, 0, 0);
+            }
         }
     }
 }
@@ -541,6 +558,22 @@ void DTreeLandPlatformWindowInterface::setEnableBlurWindow(bool enable)
         helper->setEnableBlurWindow(enable);
         if (m_platformHandle)
             Q_EMIT m_platformHandle->enableBlurWindowChanged();
+    }
+}
+
+DPlatformHandle::EffectScene DTreeLandPlatformWindowInterface::windowEffect()
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window))
+        return static_cast<DPlatformHandle::EffectScene>(helper->windowEffect().toInt());
+    return {};
+}
+
+void DTreeLandPlatformWindowInterface::setWindowEffect(DPlatformHandle::EffectScenes effectScene)
+{
+    if (auto helper = DTreeLandPlatformWindowHelper::get(m_window)) {
+        helper->setWindowEffect(effectScene);
+        if (m_platformHandle)
+            Q_EMIT m_platformHandle->windowEffectChanged();
     }
 }
 DGUI_END_NAMESPACE

--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.h
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.h
@@ -20,11 +20,12 @@ public:
     ~DTreeLandPlatformWindowHelper() override;
 
     enum Feature {
-        NoTitlebar  = 1 << 0,
-        Radius      = 1 << 1,
-        Blur        = 1 << 2,
-        Border      = 1 << 3,
-        Shadow      = 1 << 4,
+        NoTitlebar   = 1 << 0,
+        Radius       = 1 << 1,
+        Blur         = 1 << 2,
+        Border       = 1 << 3,
+        Shadow       = 1 << 4,
+        WindowEffect = 1 << 5,
     };
     Q_DECLARE_FLAGS(Features, Feature)
 
@@ -39,6 +40,7 @@ public:
     void setShadowOffset(const QPoint &shadowOffset);
     void setShadowColor(const QColor &shadowColor);
     void setEnableBlurWindow(bool enableBlurWindow);
+    void setWindowEffect(DPlatformHandle::EffectScenes effectScene);
     void setPlatformHandle(DPlatformHandle *handle);
 
     bool isEnabledNoTitlebar() const { return m_noTitlebar; }
@@ -49,6 +51,7 @@ public:
     QPoint shadowOffset() const { return m_shadowOffset; }
     QColor shadowColor() const { return m_shadowColor; }
     bool enableBlurWindow() const { return m_blur; }
+    DPlatformHandle::EffectScenes windowEffect() const { return m_effectScene; }
 
 private slots:
     void onActiveChanged();
@@ -84,6 +87,7 @@ private:
     int m_shadowRadius = 0;
     QPoint m_shadowOffset;
     QColor m_shadowColor;
+    DPlatformHandle::EffectScenes m_effectScene;
     Features m_initialized;
     Features m_dirty;
     bool m_applyScheduled = false;
@@ -118,6 +122,9 @@ public:
 
     bool enableBlurWindow() const override;
     void setEnableBlurWindow(bool enableBlurWindow) override;
+
+    DPlatformHandle::EffectScene windowEffect() override;
+    void setWindowEffect(DPlatformHandle::EffectScenes effectScene) override;
 };
 
 DGUI_END_NAMESPACE


### PR DESCRIPTION
Implement WindowEffect feature that allows disabling window border and
shadow based on parameter values: 0 disables, -1 enables defaults. This
extends the window effect enum to control individual visual elements
like border radius, shadow, and border visibility.

Log: Added window effect control for border and shadow settings

Influence:
1. Test setting window effect to 0 to verify border and shadow are
disabled
2. Test setting window effect to -1 to verify defaults are used
3. Test individual effect flags (NoRadius, NoShadow, NoBorder)
independently
4. Verify window appearance changes correctly when effects are modified
5. Test multiple platforms to ensure treeland-specific behavior doesn't
affect others

feat: 为 treeland 平台添加窗口效果支持

实现 WindowEffect 功能，根据参数值控制是否禁用窗口边框和阴影：0表示禁
用，-1表示使用默认值。通过扩展效果枚举，可单独控制圆角半径、阴影和边框等
视觉元素的可见性。

Log: 新增窗口边框和阴影效果控制功能

Influence:
1. 测试将窗口效果设为0，验证边框和阴影是否被禁用
2. 测试将窗口效果设为-1，验证是否使用默认值
3. 单独测试各个效果标志（无圆角、无阴影、无边框）的功能
4. 验证修改效果后窗口外观是否正确变化
5. 测试多个平台以确保treeland专有行为不影响其他平台
