### PR TITLE
fix: prevent pending state failure in window platform interface

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
@@ -354,7 +354,7 @@ void DTreeLandPlatformWindowHelper::scheduleApply()
     if (m_applyScheduled)
         return;
     m_applyScheduled = true;
-    QMetaObject::invokeMethod(this, &DTreeLandPlatformWindowHelper::applyPending, Qt::QueuedConnection);
+    QMetaObject::invokeMethod(this, &DTreeLandPlatformWindowHelper::applyPending);
 }
 
 void DTreeLandPlatformWindowHelper::applyPending()

--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.h
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.h
@@ -63,8 +63,6 @@ private:
 
     template<typename T>
     void updateFeature(T &member, const T &value, Feature flag) {
-        if (member == value)
-            return;
         member = value;
         m_initialized |= flag;
         m_dirty |= flag;


### PR DESCRIPTION
Remove Qt::QueuedConnection and early return to ensure pending operations always execute. The previous approach using stack variable comparisons was unreliable, causing pending state to fail intermittently. By directly invoking applyPending without queued connection and removing the unnecessary early return check, we guarantee consistent pending state application for window feature updates.

改动文件:
- src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
- src/plugins/platform/treeland/dtreelandplatformwindowinterface.h