### PR TITLE
fix: fix decorator loss when setting clipboard windows visible

### DIFF
--- a/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
+++ b/src/plugins/platform/treeland/dtreelandplatformwindowinterface.cpp
@@ -221,7 +221,7 @@ DTreeLandPlatformWindowHelper::DTreeLandPlatformWindowHelper(QWindow *window)
 DTreeLandPlatformWindowHelper::~DTreeLandPlatformWindowHelper()
 {
     if (m_windowContext) {
-        m_windowContext->deleteLater();
+        delete m_windowContext;
         m_windowContext = nullptr;
     }
     windowMap.remove(static_cast<QWindow*>(parent()));
@@ -255,8 +255,8 @@ void DTreeLandPlatformWindowHelper::initWaylandWindow()
 void DTreeLandPlatformWindowHelper::onActiveChanged()
 {
     if (PersonalizationManager::instance()->isActive()) {
-        qDebug() << "Personalization is actived, window" << window();
         if (window()->handle()) {
+            initWaylandWindow();
             onSurfaceCreated();
         }
     }
@@ -271,7 +271,7 @@ void DTreeLandPlatformWindowHelper::onSurfaceCreated()
 void DTreeLandPlatformWindowHelper::onSurfaceDestroyed()
 {
     if (m_windowContext) {
-        m_windowContext->deleteLater();
+        delete m_windowContext;
         m_windowContext = nullptr;
     }
 }


### PR DESCRIPTION
The issue was that when clipboard windows and other popup windows set
visible, decorator decorations were occasionally lost. This happened
because the Wayland window context was being scheduled for deferred
deletion via deleteLater(), which could cause a race condition where
the context was still alive when windows were hidden and shown again.
Additionally, the active changed handler wasn't reinitializing the
Wayland window properly before creating the surface.

Changes:
1. Changed deleteLater() to immediate delete for m_windowContext in
destructor and onSurfaceDestroyed
2. Added initWaylandWindow() call in onActiveChanged() before surface
creation
3. Removed debug log in onActiveChanged()

Log: Fixed decorator loss issue for clipboard windows

Influence:
1. Test clipboard window visibility toggle multiple times
2. Verify window decorations remain consistent after repeated show/
hide cycles
3. Test window context lifecycle when destroying and recreating windows
4. Verify personalization service activation handling works correctly
5. Test window active state changes with proper context initialization

fix: 修复剪切板窗口设置可见时装饰器偶现丢失问题

修复了剪切板等窗口在设置可见性时，装饰器装饰偶发丢失的问题。问题原因是
在窗口隐藏和重新显示期间，Wayland 窗口上下文通过 deleteLater() 延迟删除
可能导致竞态条件。此外，活动状态变化处理程序在创建表面前未正确重新初始化
Wayland 窗口。

更改：
1. 将析构函数和 onSurfaceDestroyed 中的 deleteLater() 改为立即删除
m_windowContext
2. 在 onActiveChanged() 中创建表面前添加 initWaylandWindow() 调用
3. 移除 onActiveChanged() 中的调试日志

Log: 修复剪切板窗口装饰器丢失问题

Influence:
1. 多次测试剪切板窗口可见性切换
2. 验证重复显示/隐藏循环后窗口装饰一致性
3. 测试窗口上下文在销毁和重新创建窗口时的生命周期
4. 验证个性化服务激活处理是否正确工作
5. 测试窗口活动状态变化时上下文初始化的正确性

## Summary by Sourcery

Fix Wayland window activation and context destruction handling to keep window decorations consistent when clipboard and popup windows are shown and hidden repeatedly.

Bug Fixes:
- Prevent loss of window decorations for clipboard and popup windows when toggling visibility under Wayland.

Enhancements:
- Improve Wayland window context lifecycle handling by deleting the context immediately on destruction and reinitializing it on activation before surface creation.