### PR TITLE
fix: prevent theme from being saved incorrectly in some applications

### DIFF
--- a/src/kernel/dguiapplicationhelper.cpp
+++ b/src/kernel/dguiapplicationhelper.cpp
@@ -473,8 +473,9 @@ void DGuiApplicationHelperPrivate::initPaletteType() const
     if (DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::DontSaveApplicationTheme))
         return;
 
-    if (_d_dconfig.exists())
+    if (paletteTypeInited)
         return;
+    const_cast<DGuiApplicationHelperPrivate *>(this)->paletteTypeInited = true;
 
     auto applyThemeType = [this](bool emitSignal){
         int ct = _d_dconfig->themeType();

--- a/src/private/dguiapplicationhelper_p.h
+++ b/src/private/dguiapplicationhelper_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -41,6 +41,7 @@ public:
     void setPaletteType(DGuiApplicationHelper::ColorType ct, bool emitSignal);
     void initPaletteType() const;
 
+    bool paletteTypeInited = false;
     DGuiApplicationHelper::ColorType paletteType = DGuiApplicationHelper::UnknownType;
     // 系统级别的主题设置
     DPlatformTheme *systemTheme = nullptr;


### PR DESCRIPTION
1. Fix a bug where some applications would save the theme type when
they shouldn't
2. Add a `paletteTypeInited` flag to track if palette type has been
initialized
3. Replace the incorrect early return check (which checked for dconfig
existence) with proper initialization tracking
4. Set the flag to true after successful initialization to prevent
repeated attempts

Log: Fixed an issue where some applications would incorrectly save the
theme type

Influence:
1. Test applications with and without DontSaveApplicationTheme attribute
2. Verify theme initialization behavior in applications that should not
save theme
3. Ensure theme is not saved on first initialization
4. Test theme change propagation after initialization

fix: 修复部分应用错误保存主题的问题

1. 修复部分应用不应保存主题类型时的错误行为
2. 添加 `paletteTypeInited` 标志位，用于跟踪调色板类型是否已初始化
3. 替换原来检查 dconfig 存在性的错误早期返回判断，采用正确的初始化状态
跟踪
4. 在成功初始化后设置标志位，防止重复初始化尝试

Log: 修复部分应用错误保存主题类型的问题

Influence:
1. 测试带有和不带 DontSaveApplicationTheme 属性的应用
2. 验证不应保存主题的应用的主题初始化行为
3. 确保在首次初始化时不保存主题
4. 测试初始化后的主题变更传播

## Summary by Sourcery

Prevent application theme type from being saved incorrectly by guarding palette initialization with an explicit initialization flag.

Bug Fixes:
- Avoid saving application theme type in applications where theme persistence is disabled by tracking palette initialization instead of relying on dconfig existence.

Enhancements:
- Introduce a palette initialization state flag to prevent repeated palette initialization and theme writes.
- Update the private header copyright notice year range.