### PR TITLE
fix: remove Q_OS_LINUX guard from DSvgRenderer to enable Windows build

### DIFF
--- a/include/util/dsvgrenderer.h
+++ b/include/util/dsvgrenderer.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -15,7 +15,6 @@ QT_BEGIN_NAMESPACE
 class QPainter;
 QT_END_NAMESPACE
 
-#ifdef Q_OS_LINUX
 DGUI_BEGIN_NAMESPACE
 class DSvgRendererPrivate;
 class DSvgRenderer : public QObject, public DTK_CORE_NAMESPACE::DObject
@@ -54,13 +53,5 @@ private:
     D_DECLARE_PRIVATE(DSvgRenderer)
 };
 DGUI_END_NAMESPACE
-#else
-
-#include <QSvgRenderer>
-DGUI_BEGIN_NAMESPACE
-typedef  QSvgRenderer DSvgRenderer;
-DGUI_END_NAMESPACE
-
-#endif
 
 #endif // DSVGRENDERER_H

--- a/src/util/dsvgrenderer.cpp
+++ b/src/util/dsvgrenderer.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <QtGlobal>
-#ifdef Q_OS_LINUX
 
 #ifndef DTK_DISABLE_LIBRSVG
 #include <librsvg/rsvg.h>
@@ -438,5 +437,3 @@ void DSvgRenderer::render(QPainter *p, const QString &elementId, const QRectF &b
 }
 
 DGUI_END_NAMESPACE
-
-#endif // Q_OS_LINUX


### PR DESCRIPTION
DSvgRenderer was entirely wrapped in #ifdef Q_OS_LINUX, making it unavailable on Windows. The DTK_DISABLE_LIBRSVG fallback path already uses Qt's QSvgRenderer which is cross-platform, so the Linux-only guard was unnecessary.

Remove the #ifdef Q_OS_LINUX / #endif wrapper from both dsvgrenderer.h and dsvgrenderer.cpp. On Windows (where librsvg is not available), DSvgRenderer now correctly falls back to QSvgRenderer via the DTK_DISABLE_LIBRSVG code path.

This fixes the undefined reference linker errors for dtk6-svgc on Windows/MSYS2.