### PR TITLE
fix: remove noise qWarning in setWmWindowTypes when platform window not ready

### DIFF
--- a/src/kernel/dwindowmanagerhelper.cpp
+++ b/src/kernel/dwindowmanagerhelper.cpp
@@ -497,10 +497,15 @@ void DWindowManagerHelper::setWmWindowTypes(QWindow *window, WmWindowTypes types
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     typedef QNativeInterface::Private::QXcbWindow  QXcbWindow_P;
-    if (auto w = dynamic_cast<QXcbWindow_P *>(window->handle())) {
-        w->setWindowType(static_cast<D_XCB_WINDOW_TYPE>(_types));
-    } else {
-        qWarning() << "cast" << window << "to platform window failed";
+    // _NET_WM_WINDOW_TYPE 是 X11 专属属性，仅在 XCB 平台窗口已创建时生效。
+    // 当 window 为空、handle 为空（平台窗口尚未创建，常见于 QML 组件完成阶段）
+    // 或为非 XCB 平台（如 Wayland/Treeland）时无法应用，静默忽略即可，
+    // 与 Qt5 下 QXcbWindowFunctions::setWmWindowType 及本类 setMotifFunctions/
+    // setMotifDecorations/popupSystemWindowMenu 的处理方式一致，避免对 QML 窗口产生噪声告警。
+    if (window) {
+        if (auto w = dynamic_cast<QXcbWindow_P *>(window->handle())) {
+            w->setWindowType(static_cast<D_XCB_WINDOW_TYPE>(_types));
+        }
     }
 #else
     QXcbWindowFunctions::setWmWindowType(window, static_cast<D_XCB_WINDOW_TYPE>(_types));


### PR DESCRIPTION
## Summary

Remove the noisy runtime warning emitted by `DWindowManagerHelper::setWmWindowTypes` when the platform window is not ready or not on XCB.

When adding a new user in dde-control-center (accounts module), the following warning was logged:

```
Dtk::Gui::DWindowManagerHelper::setWmWindowTypes:502 cast CreateAccountDialog_QMLTYPE_297(...) to platform window failed
```

## Root cause

`setWmWindowTypes` is invoked during the QML component-complete phase (via the `D.DWindow.wmWindowTypes` binding in dtkdeclarative), at which point `window->handle()` is still `nullptr`. The Qt6 code unconditionally `qWarning`s whenever `dynamic_cast<QXcbWindow_P*>(window->handle())` fails. That cast fails in two **normal** situations that are not errors:

- **Platform window not yet created** — `window->handle()` is `nullptr` (common during the QML component-complete phase where `D.DWindow.wmWindowTypes` is evaluated before the underlying `QWindow` is exposed).
- **Non-XCB platform** — on Wayland/Treeland the handle is a `QWaylandWindow`, not an `QXcbWindow`.

`_NET_WM_WINDOW_TYPE` is an X11-only property, so in both cases there is legitimately nothing to do. The Qt5 path (`QXcbWindowFunctions::setWmWindowType`) was already a silent no-op here; the Qt6 port introduced the unconditional `qWarning` and turned a normal no-op into noise.

## Change

File: `src/kernel/dwindowmanagerhelper.cpp` — `DWindowManagerHelper::setWmWindowTypes`, Qt6 branch only.

- Removed the unconditional `qWarning` (the whole `else` branch).
- Guard with `if (window)` (null-pointer safety), then `dynamic_cast<QXcbWindow_P*>(window->handle())` — `window->handle()` is called only once; a null handle safely yields `nullptr` from the cast (silent no-op).
- Non-applicable cases (null window, null handle, non-XCB platform) all fall through silently — consistent with `popupSystemWindowMenu`, `setMotifFunctions` and `setMotifDecorations` in the same file, and restoring the Qt5 silent behavior.
- The Qt5 `#else` branch and the `#ifdef Q_OS_LINUX` guard are unchanged. No header / API / ABI change.

```diff
@@ -497,10 +497,15 @@ void DWindowManagerHelper::setWmWindowTypes(QWindow *window, WmWindowTypes types

 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     typedef QNativeInterface::Private::QXcbWindow  QXcbWindow_P;
-    if (auto w = dynamic_cast<QXcbWindow_P *>(window->handle())) {
-        w->setWindowType(static_cast<D_XCB_WINDOW_TYPE>(_types));
-    } else {
-        qWarning() << "cast" << window << "to platform window failed";
+    // _NET_WM_WINDOW_TYPE 是 X11 专属属性，仅在 XCB 平台窗口已创建时生效。
+    // 当 window 为空、handle 为空（平台窗口尚未创建，常见于 QML 组件完成阶段）
+    // 或为非 XCB 平台（如 Wayland/Treeland）时无法应用，静默忽略即可，
+    // 与 Qt5 下 QXcbWindowFunctions::setWmWindowType 及本类 setMotifFunctions/
+    // setMotifDecorations/popupSystemWindowMenu 的处理方式一致，避免对 QML 窗口产生噪声告警。
+    if (window) {
+        if (auto w = dynamic_cast<QXcbWindow_P *>(window->handle())) {
+            w->setWindowType(static_cast<D_XCB_WINDOW_TYPE>(_types));
+        }
     }
 #else
     QXcbWindowFunctions::setWmWindowType(window, static_cast<D_XCB_WINDOW_TYPE>(_types));
```

## Testing

- The existing unit test `tests/src/ut_dwindowmanagerhelper.cpp` only expects "no crash" for this function; behavior is preserved.
- Verify the warning no longer appears when opening the "add new user" dialog in dde-control-center.
- Confirm `wmWindowTypes` still applies on X11 once the platform window is created.
- Verify no regression on Wayland/Treeland (the call remains a no-op).

> Draft PR — please review. Do not merge until approved.

Related Multica issue: DDE-111

## Summary by Sourcery

Bug Fixes:
- Prevent noisy qWarning logs when setWmWindowTypes is called before the platform window handle is created or on non-X11 platforms by treating these cases as silent no-ops.