### PR TITLE
fix: align dtk gui dev package deps with tools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -63,6 +63,7 @@ Description: Development ToolKit Gui Utilities (DTK6 with Qt6)
 Package: libdtk6gui-dev
 Architecture: any
 Depends: libdtk6gui( =${binary:Version}),
+ libdtk6gui-bin( =${binary:Version}),
  libdtkcommon-dev(>=5.6.16), libdtk6core-dev
 Build-Profiles: <!nodtk6>
 Description: Development ToolKit Gui Devel Library (DTK6 with Qt6)
@@ -103,6 +104,7 @@ Description: Development ToolKit Gui Utilities (DTK5 with Qt5)
 Package: libdtkgui-dev
 Architecture: any
 Depends: libdtkgui5( =${binary:Version}),
+ libdtkgui5-bin( =${binary:Version}),
  libdtkcommon-dev(>=5.6.16), libdtkcore-dev
 Build-Profiles: <!nodtk5>
 Description: Development ToolKit Gui Devel Library (DTK5 with Qt5)


### PR DESCRIPTION
1. Add version-matched dependency on libdtk6gui-bin to libdtk6gui-dev
2. Add version-matched dependency on libdtkgui5-bin to libdtkgui-dev
3. Ensure development packages pull in corresponding tool packages
4. Prevent version mismatch between GUI libraries and their tools

Influence:
1. Verify debian/control syntax is valid with dpkg-checkbuilddeps
2. Rebuild packages and confirm correct dependencies are generated
3. Test installation of libdtk6gui-dev pulls the matching libdtk6gui-
bin version
4. Test installation of libdtkgui-dev pulls the matching libdtkgui5-
bin version
5. Verify no conflicting versions are installed during upgrades
6. Confirm the change applies to both DTK5 and DTK6 variants

chore: 使DTK GUI开发包依赖匹配的工具包

1. 为 libdtk6gui-dev 添加版本匹配的 libdtk6gui-bin 依赖
2. 为 libdtkgui-dev 添加版本匹配的 libdtkgui5-bin 依赖
3. 确保开发包引入对应的工具包
4. 防止GUI库与其工具之间出现版本不匹配

Influence:
1. 使用 dpkg-checkbuilddeps 验证 debian/control 语法有效性
2. 重新构建包并确认生成的依赖正确
3. 测试安装 libdtk6gui-dev 时拉取匹配版本的 libdtk6gui-bin
4. 测试安装 libdtkgui-dev 时拉取匹配版本的 libdtkgui5-bin
5. 验证升级过程中不会安装冲突版本
6. 确认更改同时适用于 DTK5 和 DTK6 变体

## Summary by Sourcery

Align DTK GUI development package dependencies with their corresponding tool binaries to ensure version consistency across DTK5 and DTK6 variants.

Bug Fixes:
- Ensure libdtk6gui-dev depends on the matching version of libdtk6gui-bin to avoid version mismatches between the library and its tools.
- Ensure libdtkgui-dev depends on the matching version of libdtkgui5-bin to prevent conflicting versions during installation and upgrades.

Build:
- Adjust debian/control package dependency declarations so development packages pull in the corresponding versioned tool packages.